### PR TITLE
Exclude system_admin users and allow multiple users per branch

### DIFF
--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -62,16 +62,20 @@ export class UserModel {
 
   static async findAll(): Promise<User[]> {
     const [rows] = await connection.query<any[]>(
-      'SELECT u.*, b.branch_name AS branchName FROM users u LEFT JOIN branches b ON u.branch_id = b.id ORDER BY u.created_at DESC'
+      'SELECT u.*, b.branch_name AS branchName FROM users u LEFT JOIN branches b ON u.branch_id = b.id WHERE u.role <> ? ORDER BY u.created_at DESC',
+      ['system_admin']
     );
     return (rows as any[]);
   }
 
   static async searchUsers(searchQuery: string, roles?: string[], limit?: number): Promise<User[]> {
     const params: any[] = [];
-    let sql = 'SELECT u.*, b.branch_name AS branchName FROM users u LEFT JOIN branches b ON u.branch_id = b.id WHERE (u.first_name LIKE ? OR u.last_name LIKE ? OR u.email LIKE ?)';
+    let sql = 'SELECT u.*, b.branch_name AS branchName FROM users u LEFT JOIN branches b ON u.branch_id = b.id WHERE (u.first_name LIKE ? OR u.last_name LIKE ? OR u.email LIKE ?)' ;
     const q = `%${searchQuery}%`;
     params.push(q, q, q);
+    // Always exclude system_admin
+    sql += ' AND u.role <> ?';
+    params.push('system_admin');
     if (roles && roles.length > 0) {
       sql += ` AND u.role IN (${roles.map(() => '?').join(',')})`;
       params.push(...roles);

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -26,12 +26,6 @@ export class UserService {
   static async createUser(userData: InsertUser): Promise<User> {
     if (!userData.email) throw new Error('email is required');
     if (!userData.branchId) throw new Error('branchId is required');
-    if (userData.branchId) {
-      const existing = await UserModel.findByBranchId(userData.branchId);
-      if (existing) {
-        throw new Error('branch already assigned to another user');
-      }
-    }
     const data: InsertUser = {
       ...userData,
       isActive: false,
@@ -44,12 +38,6 @@ export class UserService {
   static async createUserWithPassword(userData: InsertUser, password: string): Promise<User> {
     if (!userData.email) throw new Error('email is required');
     if (!userData.branchId) throw new Error('branchId is required');
-    if (userData.branchId) {
-      const existing = await UserModel.findByBranchId(userData.branchId);
-      if (existing) {
-        throw new Error('branch already assigned to another user');
-      }
-    }
     const data: InsertUser = {
       ...userData,
       isActive: false,
@@ -61,12 +49,6 @@ export class UserService {
   }
 
   static async updateUser(id: string, updates: Partial<InsertUser>): Promise<User | undefined> {
-    if (updates.branchId) {
-      const existing = await UserModel.findByBranchId(updates.branchId);
-      if (existing && existing.id !== id) {
-        throw new Error('branch already assigned to another user');
-      }
-    }
     return await UserModel.update(id, updates);
   }
 

--- a/frontend/src/components/settings/RegionSection.tsx
+++ b/frontend/src/components/settings/RegionSection.tsx
@@ -589,7 +589,7 @@ export default function RegionSection({ toast }: { toast: (v: any) => void }) {
                                                   >
                                                     <SelectTrigger className="h-7 text-xs w-48">
                                                       {(() => {
-                                                        const sel = String(branchHeadDraft[String(b.id)] ?? currentHeadId || '');
+                                                        const sel = String((branchHeadDraft[String(b.id)] ?? currentHeadId) || '');
                                                         const u = (users as any[]).find((x: any) => String(x.id) === sel);
                                                         const label = u ? ([u.firstName, u.lastName].filter(Boolean).join(' ') || u.email || '-') : 'Select head';
                                                         return <span className="truncate text-left w-full">{label}</span>;

--- a/frontend/src/components/settings/RegionSection.tsx
+++ b/frontend/src/components/settings/RegionSection.tsx
@@ -587,7 +587,14 @@ export default function RegionSection({ toast }: { toast: (v: any) => void }) {
                                                     }}
                                                     disabled={updatingBranchId === String(b.id)}
                                                   >
-                                                    <SelectTrigger className="h-7 text-xs w-48"><SelectValue placeholder="Select head" /></SelectTrigger>
+                                                    <SelectTrigger className="h-7 text-xs w-48">
+                                                      {(() => {
+                                                        const sel = String(branchHeadDraft[String(b.id)] ?? currentHeadId || '');
+                                                        const u = (users as any[]).find((x: any) => String(x.id) === sel);
+                                                        const label = u ? ([u.firstName, u.lastName].filter(Boolean).join(' ') || u.email || '-') : 'Select head';
+                                                        return <span className="truncate text-left w-full">{label}</span>;
+                                                      })()}
+                                                    </SelectTrigger>
                                                     <SelectContent>
                                                       {options.map((u: any) => (
                                                         <SelectItem key={u.id} value={String(u.id)}>

--- a/frontend/src/components/settings/RegionSection.tsx
+++ b/frontend/src/components/settings/RegionSection.tsx
@@ -46,6 +46,7 @@ export default function RegionSection({ toast }: { toast: (v: any) => void }) {
   const [branchHeadDraft, setBranchHeadDraft] = useState<Record<string, string>>({});
   const [updatingBranchId, setUpdatingBranchId] = useState<string | null>(null);
   const [removingBranchId, setRemovingBranchId] = useState<string | null>(null);
+  const [fadeOutBranchId, setFadeOutBranchId] = useState<string | null>(null);
   const [sort, setSort] = useState<{ by: 'name' | 'head' | 'branches'; dir: 'asc' | 'desc' }>({ by: 'name', dir: 'asc' });
 
   const toggleExpand = (id: string) => {
@@ -193,6 +194,7 @@ export default function RegionSection({ toast }: { toast: (v: any) => void }) {
     },
     onMutate: async ({ branchId }) => {
       setRemovingBranchId(branchId);
+      setTimeout(() => setFadeOutBranchId(branchId), 250);
     },
     onSuccess: async () => {
       await Promise.all([refetch(), refetchBranches()]);
@@ -204,6 +206,7 @@ export default function RegionSection({ toast }: { toast: (v: any) => void }) {
     },
     onSettled: () => {
       setRemovingBranchId(null);
+      setFadeOutBranchId(null);
     }
   });
 
@@ -603,15 +606,16 @@ export default function RegionSection({ toast }: { toast: (v: any) => void }) {
                                           const currentHeadId = String(b.branchHeadId || b.managerId || '');
                                           const options = branchHeadOptionsForEdit(b);
                                           return (
-                                            <TableRow key={b.id}>
+                                            <TableRow key={b.id} className={(removingBranchId === String(b.id) ? 'line-through text-muted-foreground' : '') + ' ' + (fadeOutBranchId === String(b.id) ? 'opacity-0 transition-opacity duration-500' : '')}>
                                               <TableCell className="p-2 text-xs">
                                                 <div className="flex items-center gap-1">
                                                   <Button
                                                     type="button"
                                                     size="icon"
-                                                    variant="ghost"
+                                                    variant="destructive"
                                                     className="h-6 w-6 -ml-1"
                                                     title="Remove from region"
+                                                    aria-label="Remove from region"
                                                     onClick={() => removeBranchFromRegion.mutate({ branchId: String(b.id) })}
                                                     disabled={removingBranchId === String(b.id) || removeBranchFromRegion.isPending}
                                                   >

--- a/frontend/src/components/settings/RegionSection.tsx
+++ b/frontend/src/components/settings/RegionSection.tsx
@@ -516,33 +516,42 @@ export default function RegionSection({ toast }: { toast: (v: any) => void }) {
                             <TableRow>
                               <TableCell colSpan={5} className="p-0 bg-muted/20">
                                 <div className="p-2 space-y-2">
-                                  <div className="flex items-center gap-2 p-2 rounded border bg-background/80">
-                                    <div className="text-xs font-medium">Add branch to this region</div>
+                                  <div className="flex flex-col sm:flex-row sm:items-center gap-2 p-3 rounded-md border bg-gradient-to-r from-muted/40 via-background to-background">
+                                    <div className="flex items-center gap-2 min-w-[220px]">
+                                      <div className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-primary">+</div>
+                                      <div>
+                                        <div className="text-xs font-semibold">Add branch to this region</div>
+                                        <div className="text-[11px] text-muted-foreground">Select one or more unassigned branches</div>
+                                      </div>
+                                    </div>
                                     <div className="flex-1" />
                                     {(() => {
                                       const unassigned = (branches as any[]).filter((b: any) => !b.regionId);
                                       const options = unassigned.map((b: any) => ({ value: String(b.id), label: `${b.branchName || b.name || '-' }${b.city ? `, ${b.city}` : ''}` }));
+                                      const selected = pendingAssign[String(r.id)] || [];
                                       return (
-                                        <MultiSelect
-                                          value={pendingAssign[String(r.id)] || []}
-                                          onValueChange={(vals) => setPendingAssign((s) => ({ ...s, [String(r.id)]: vals }))}
-                                          options={options}
-                                          placeholder={unassigned.length === 0 ? 'No unassigned branches' : 'Select branches'}
-                                          className="h-7 min-h-7 w-64 text-xs"
-                                        />
+                                        <div className="flex items-center gap-2">
+                                          <MultiSelect
+                                            value={selected}
+                                            onValueChange={(vals) => setPendingAssign((s) => ({ ...s, [String(r.id)]: vals }))}
+                                            options={options}
+                                            placeholder={unassigned.length === 0 ? 'No unassigned branches' : 'Choose branches...'}
+                                            className="h-8 min-h-8 w-[320px] text-xs"
+                                          />
+                                          <Button
+                                            size="sm"
+                                            className="h-8"
+                                            onClick={() => {
+                                              if (selected.length === 0) return;
+                                              bulkAssignMutation.mutate({ branchIds: selected, regionId: String(r.id) });
+                                            }}
+                                            disabled={selected.length === 0 || bulkAssignMutation.isPending}
+                                          >
+                                            {bulkAssignMutation.isPending ? 'Adding…' : `Add${selected.length > 0 ? ` ${selected.length}` : ''}`}
+                                          </Button>
+                                        </div>
                                       );
                                     })()}
-                                    <Button
-                                      size="sm"
-                                      onClick={() => {
-                                        const bids = pendingAssign[String(r.id)] || [];
-                                        if (bids.length === 0) return;
-                                        bulkAssignMutation.mutate({ branchIds: bids, regionId: String(r.id) });
-                                      }}
-                                      disabled={!pendingAssign[String(r.id)] || (pendingAssign[String(r.id)]?.length || 0) === 0 || bulkAssignMutation.isPending}
-                                    >
-                                      {bulkAssignMutation.isPending ? 'Adding...' : `Add${(pendingAssign[String(r.id)]?.length || 0) > 0 ? ` ${pendingAssign[String(r.id)].length}` : ''}`}
-                                    </Button>
                                   </div>
 
                                   {branchCount === 0 ? (

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -15,8 +15,8 @@ type AllowedCategory = typeof ALLOWED[number];
 export default function Settings() {
   const { toast } = useToast();
   const [category, setCategory] = useState<AllowedCategory>(() => {
-    const saved = (localStorage.getItem('settings_category') as AllowedCategory | null) || 'users';
-    return (ALLOWED as readonly string[]).includes(saved) ? (saved as AllowedCategory) : 'users';
+    const saved = (localStorage.getItem('settings_category') as AllowedCategory | null) || 'regions';
+    return (ALLOWED as readonly string[]).includes(saved) ? (saved as AllowedCategory) : 'regions';
   });
 
   useEffect(() => {

--- a/frontend/src/pages/settings.tsx
+++ b/frontend/src/pages/settings.tsx
@@ -28,14 +28,14 @@ export default function Settings() {
       <div className="space-y-3">
         {/* Top bar tabs */}
         <div className="flex flex-wrap items-center gap-2">
-          <Button type="button" variant={category === 'users' ? 'default' : 'outline'} onClick={() => setCategory('users')} className="gap-2">
-            <ShieldCheck className="w-4 h-4" /> User management
+          <Button type="button" variant={category === 'regions' ? 'default' : 'outline'} onClick={() => setCategory('regions')} className="gap-2">
+            <Globe2 className="w-4 h-4" /> Region manager
           </Button>
           <Button type="button" variant={category === 'branches' ? 'default' : 'outline'} onClick={() => setCategory('branches')} className="gap-2">
             <Database className="w-4 h-4" /> Branch management
           </Button>
-          <Button type="button" variant={category === 'regions' ? 'default' : 'outline'} onClick={() => setCategory('regions')} className="gap-2">
-            <Globe2 className="w-4 h-4" /> Region management
+          <Button type="button" variant={category === 'users' ? 'default' : 'outline'} onClick={() => setCategory('users')} className="gap-2">
+            <ShieldCheck className="w-4 h-4" /> User management
           </Button>
           <Button type="button" variant={category === 'smtp' ? 'default' : 'outline'} onClick={() => setCategory('smtp')} className="gap-2">
             <Mail className="w-4 h-4" /> Email (SMTP)

--- a/frontend/src/services/users.ts
+++ b/frontend/src/services/users.ts
@@ -1,7 +1,8 @@
 import { http } from './http';
 
 export async function getUsers() {
-  return http.get<any[]>('/api/users');
+  const res = await http.get<any[]>('/api/users');
+  return (Array.isArray(res) ? res : []).filter((u: any) => String(u.role) !== 'system_admin');
 }
 
 export async function updateUser(id: string | null, data: any) {


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user wanted to:
- Allow multiple Counsellors and Admission Officers per branch (removing the one-user-per-branch restriction)
- Reorganize settings tabs with Region manager first, then Branch management, then User management
- Improve the region manager UI with better styling for adding branches to regions
- Add functionality to remove branches from regions with red minus buttons and strike-through animation
- Hide system_admin users from all CRM selections and user listings

## Code changes

**Backend changes:**
- Modified `UserModel.findAll()` and `UserModel.searchUsers()` to exclude users with role `system_admin`
- Removed branch assignment validation in `UserService` that prevented multiple users per branch
- Added WHERE clause filtering out system_admin users from all user queries

**Frontend changes:**
- Reordered settings tabs: Region manager → Branch management → User management
- Enhanced region manager UI with improved styling for the "Add branch to region" section
- Added red minus buttons to remove branches from regions with strike-through animation effects
- Added client-side filtering to exclude system_admin users from user listings
- Improved branch head selection dropdown with proper value display
- Added loading states and better UX for branch removal operationsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/48be7d7ff6ef4342a930947edc4100f8/spark-studio)

👀 [Preview Link](https://48be7d7ff6ef4342a930947edc4100f8-spark-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>48be7d7ff6ef4342a930947edc4100f8</projectId>-->
<!--<branchName>spark-studio</branchName>-->