### PR TITLE
Refactor role-based validation for Operations department

### DIFF
--- a/frontend/src/components/settings/UserSection.tsx
+++ b/frontend/src/components/settings/UserSection.tsx
@@ -674,7 +674,11 @@ export default function UserSection({ toast }: { toast: (v: any) => void }) {
                           placeholder="Select branch (required)"
                           searchPlaceholder="Search branches..."
                           onSearch={setBranchEditSearch}
-                          options={(branchEditList || []).filter((b: any) => (!editForm.regionId || String(b.regionId ?? b.region_id) === String(editForm.regionId))).map((b: any) => ({ value: String(b.id), label: String(b.branchName || b.name || b.id) }))}
+                          options={(branchEditList || []).filter((b: any) => {
+                            if (nRole === 'branch_manager' && (b.branchHeadId ?? b.branch_head_id)) return false;
+                            if (editForm.regionId && String(b.regionId ?? b.region_id) !== String(editForm.regionId)) return false;
+                            return true;
+                          }).map((b: any) => ({ value: String(b.id), label: String(b.branchName || b.name || b.id) }))}
                           loading={Boolean(branchEditTrim.length > 0 && branchEditIsFetching)}
                         />
                       </div>


### PR DESCRIPTION
## Purpose

The user requested changes to the Operations department role selection behavior:
- When Operations department is selected, the role dropdown should show "Please Select Role" instead of auto-selecting Regional Manager
- Regional Manager role should show region dropdown
- Branch Manager, Counsellor, and Admission Officer roles should show both region and branch dropdowns (with branch dependent on region selection)

## Code changes

- **Removed auto-assignment**: Eliminated automatic role assignment to "regional_manager" when Operations department is selected
- **Standardized role validation**: Replaced department-based validation logic with role-based validation using a new `normalizeRole()` helper function
- **Improved role normalization**: Added `normalizeRole()` function to handle role name variations (e.g., "counsellor" → "counselor")
- **Updated placeholder text**: Changed role dropdown placeholder to consistently show "Please Select Role"
- **Consolidated validation logic**: Unified validation rules for both create and edit forms based on normalized role names
- **Enhanced branch filtering**: Improved branch filtering logic to work consistently across different role types

The changes ensure that role selection is now user-driven rather than department-driven, while maintaining proper validation requirements for each role type.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 43`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a056a0e422594fe7a1ef14269b1a8c53/pixel-forge)

👀 [Preview Link](https://a056a0e422594fe7a1ef14269b1a8c53-pixel-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a056a0e422594fe7a1ef14269b1a8c53</projectId>-->
<!--<branchName>pixel-forge</branchName>-->