### PR TITLE
Fix branch manager data and remove branch column

### DIFF
--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -70,7 +70,7 @@ export class UserModel {
 
   static async findAll(): Promise<User[]> {
     const [rows] = await connection.query<any[]>(
-      'SELECT u.*, COALESCE(ur.role_name, u.role_id) AS role, be.branch_id as branchId, b.branch_name AS branchName FROM users u LEFT JOIN user_roles ur ON ur.id = u.role_id LEFT JOIN branch_emps be ON be.user_id = u.id LEFT JOIN branches b ON be.branch_id = b.id WHERE COALESCE(ur.role_name, u.role_id) <> ? ORDER BY u.created_at DESC',
+      'SELECT u.*, COALESCE(ur.role_name, u.role_id) AS role, COALESCE(be.branch_id, hb.id) as branchId, COALESCE(b.branch_name, hb.branch_name) AS branchName, a.path AS profileImageUrl FROM users u LEFT JOIN user_roles ur ON ur.id = u.role_id LEFT JOIN attachments a ON a.id = u.profile_image_id LEFT JOIN branch_emps be ON be.user_id = u.id LEFT JOIN branches b ON be.branch_id = b.id LEFT JOIN branches hb ON hb.branch_head_id = u.id WHERE COALESCE(ur.role_name, u.role_id) <> ? ORDER BY u.created_at DESC',
       ['system_admin']
     );
     return (rows as any[]);
@@ -78,7 +78,7 @@ export class UserModel {
 
   static async searchUsers(searchQuery: string, roles?: string[], limit?: number): Promise<User[]> {
     const params: any[] = [];
-    let sql = 'SELECT u.*, COALESCE(ur.role_name, u.role_id) AS role, be.branch_id as branchId, b.branch_name AS branchName FROM users u LEFT JOIN user_roles ur ON ur.id = u.role_id LEFT JOIN branch_emps be ON be.user_id = u.id LEFT JOIN branches b ON be.branch_id = b.id WHERE (u.first_name LIKE ? OR u.last_name LIKE ? OR u.email LIKE ?)';
+    let sql = 'SELECT u.*, COALESCE(ur.role_name, u.role_id) AS role, COALESCE(be.branch_id, hb.id) as branchId, COALESCE(b.branch_name, hb.branch_name) AS branchName, a.path AS profileImageUrl FROM users u LEFT JOIN user_roles ur ON ur.id = u.role_id LEFT JOIN attachments a ON a.id = u.profile_image_id LEFT JOIN branch_emps be ON be.user_id = u.id LEFT JOIN branches b ON be.branch_id = b.id LEFT JOIN branches hb ON hb.branch_head_id = u.id WHERE (u.first_name LIKE ? OR u.last_name LIKE ? OR u.email LIKE ?)';
     const q = `%${searchQuery}%`;
     params.push(q, q, q);
     // Always exclude system_admin

--- a/frontend/src/components/settings/UserSection.tsx
+++ b/frontend/src/components/settings/UserSection.tsx
@@ -503,7 +503,6 @@ export default function UserSection({ toast }: { toast: (v: any) => void }) {
                   <TableHead className="h-8 px-2 text-[11px]">Name</TableHead>
                   <TableHead className="h-8 px-2 text-[11px]">Email</TableHead>
                   <TableHead className="h-8 px-2 text-[11px]">Role</TableHead>
-                  <TableHead className="h-8 px-2 text-[11px]">Branch</TableHead>
                   <TableHead className="h-8 px-2 text-[11px]">Active</TableHead>
                 </TableRow>
               </TableHeader>
@@ -526,7 +525,6 @@ export default function UserSection({ toast }: { toast: (v: any) => void }) {
                     <TableCell className="p-2 text-xs">{[(u.firstName ?? u.first_name), (u.lastName ?? u.last_name)].filter(Boolean).join(' ') || '—'}</TableCell>
                     <TableCell className="p-2 text-xs">{u.email}</TableCell>
                     <TableCell className="p-2 text-xs">{roleLabel(u.role)}</TableCell>
-                    <TableCell className="p-2 text-xs">{u.branchName || u.branchId || u.branch_id || '—'}</TableCell>
                     <TableCell className="p-2 text-xs">{(u.isActive ?? u.is_active) ? 'Yes' : 'No'}</TableCell>
                   </TableRow>
                 ))}


### PR DESCRIPTION
## Purpose

Fix issues with branch manager user data display where branch names and profile images were not showing correctly. The backend was returning null values for branch information for branch managers, and the frontend needed to remove the branch column from the user listing table as requested.

## Code changes

**Backend (User.ts):**
- Enhanced SQL queries in `findAll()` and `searchUsers()` methods to properly join with branches table using `branch_head_id` for branch managers
- Added `COALESCE` logic to get branch data from either employee assignments or branch head relationships
- Added profile image URL retrieval by joining with attachments table using `profile_image_id`

**Frontend (UserSection.tsx):**
- Removed "Branch" column header from the user listing table
- Removed branch data display from table rows as requestedTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d97fe797e6ed4a47b24c2ae65f7aa944/aura-works)

👀 [Preview Link](https://d97fe797e6ed4a47b24c2ae65f7aa944-aura-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d97fe797e6ed4a47b24c2ae65f7aa944</projectId>-->
<!--<branchName>aura-works</branchName>-->