### PR TITLE
Add role details to JWT token and activate users on wizard completion

### DIFF
--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -21,17 +21,62 @@ export class AuthController {
       if (!user) return res.status(401).json({ error: "Invalid email or password" });
 
       const { signAccessToken } = await import("../utils/jwt.js");
-      const token = signAccessToken({ sub: user.id, role: (user as any).role });
-      const isProd = process.env.NODE_ENV === 'production';
-      res.cookie('access_token', token, {
-        httpOnly: true,
-        sameSite: 'none',
-        secure: true,
-        maxAge: 15 * 60 * 1000,
-        path: '/',
-      });
+      // Fetch role/branch/region details for the user to include in token
+      try {
+        const { connection } = await import('../config/database.js');
+        const sql = `SELECT ur.role_name AS role_name, COALESCE(r.id, r2.id, r3.id) AS region_id, COALESCE(r.region_name, r2.region_name, r3.region_name) AS region_name, COALESCE(b.id, b2.id) AS branch_id, COALESCE(b.branch_name, b2.branch_name) AS branch_name
+          FROM users u
+          JOIN user_roles ur ON u.role_id = ur.id
+          LEFT JOIN regions r ON r.region_head_id = u.id
+          LEFT JOIN branches b ON b.branch_head_id = u.id
+          LEFT JOIN branch_emps be ON be.user_id = u.id
+          LEFT JOIN branches b2 ON b2.id = be.branch_id
+          LEFT JOIN regions r2 ON r2.id = b2.branch_region
+          LEFT JOIN regions r3 ON r3.id = b2.branch_region
+          WHERE u.id = ? LIMIT 1`;
+        const [rows] = await connection.query<any[]>(sql, [user.id]);
+        const row = Array.isArray(rows) && rows.length > 0 ? rows[0] : null;
+        const roleDetails = row ? {
+          role_name: row.role_name ?? null,
+          region_id: row.region_id ?? null,
+          region_name: row.region_name ?? null,
+          branch_id: row.branch_id ?? null,
+          branch_name: row.branch_name ?? null,
+        } : null;
 
-      res.json({ user, token, expiresIn: 15 * 60 });
+        // Attach to the user object returned in response
+        (user as any).role_details = roleDetails;
+
+        // Include role details in JWT payload (be mindful of token size)
+        const tokenPayload: any = { sub: user.id, role: (user as any).role };
+        if (roleDetails) tokenPayload.role_details = roleDetails;
+
+        const token = signAccessToken(tokenPayload);
+        res.cookie('access_token', token, {
+          httpOnly: true,
+          sameSite: 'none',
+          secure: true,
+          maxAge: 15 * 60 * 1000,
+          path: '/',
+        });
+
+        res.json({ user, token, expiresIn: 15 * 60 });
+        return;
+      } catch (fetchErr) {
+        console.error('Failed to fetch role details for token:', fetchErr);
+        // Fallback: sign basic token without role_details
+        const token = signAccessToken({ sub: user.id, role: (user as any).role });
+        res.cookie('access_token', token, {
+          httpOnly: true,
+          sameSite: 'none',
+          secure: true,
+          maxAge: 15 * 60 * 1000,
+          path: '/',
+        });
+
+        res.json({ user, token, expiresIn: 15 * 60 });
+        return;
+      }
     } catch (error) {
       console.error("Login error:", error);
       res.status(400).json({ error: "Invalid request" });

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -103,7 +103,9 @@ export class AuthController {
       if (!token) return res.status(401).json({ message: 'Unauthorized' });
       const payload = verifyAccessToken(token);
       if (!payload) return res.status(401).json({ message: 'Unauthorized' });
-      res.json({ id: payload.sub, role: payload.role });
+      const out: any = { id: payload.sub, role: payload.role };
+      if (payload.role_details) out.role_details = payload.role_details;
+      res.json(out);
     } catch (error) {
       res.status(401).json({ message: 'Unauthorized' });
     }

--- a/frontend/src/components/settings/UserProfileWizard.tsx
+++ b/frontend/src/components/settings/UserProfileWizard.tsx
@@ -135,6 +135,7 @@ export default function UserProfileWizard() {
       payload.isProfileComplete = true;
       // Activate user
       payload.is_active = 1;
+      payload.isActive = true;
 
       await UsersService.updateUser(String(user.id), payload);
 

--- a/frontend/src/components/settings/UserProfileWizard.tsx
+++ b/frontend/src/components/settings/UserProfileWizard.tsx
@@ -133,6 +133,8 @@ export default function UserProfileWizard() {
       if (profileImageId) payload.profileImageId = profileImageId;
       // Mark profile complete
       payload.isProfileComplete = true;
+      // Activate user
+      payload.is_active = 1;
 
       await UsersService.updateUser(String(user.id), payload);
 


### PR DESCRIPTION
## Purpose

Based on user requirements to enhance the authentication system by:
- Including detailed role/branch/region information in JWT tokens during login
- Automatically activating users when they complete the profile wizard
- Providing comprehensive user context for role-based access control

## Code changes

**AuthController.ts:**
- Added complex SQL query to fetch user role details including role_name, region_id, region_name, branch_id, and branch_name
- Enhanced JWT token payload to include nested `role_details` object
- Updated `/me` endpoint to return role details from token payload
- Added error handling with fallback to basic token if role details fetch fails

**UserProfileWizard.tsx:**
- Added `is_active = 1` and `isActive = true` to user update payload when completing the wizard
- Ensures users are automatically activated upon profile completionTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 54`

🔗 [Edit in Builder.io](https://builder.io/app/projects/306e7ca5d4554070b51917b2181de4e7/spark-verse)

👀 [Preview Link](https://306e7ca5d4554070b51917b2181de4e7-spark-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>306e7ca5d4554070b51917b2181de4e7</projectId>-->
<!--<branchName>spark-verse</branchName>-->