### PR TITLE
Update lead details modal header and activity layout

### DIFF
--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -369,8 +369,10 @@ export function ActivityTracker({ entityType, entityId, entityName, initialInfo,
                             <AvatarImage className="object-cover" src={profileImage || ''} alt={activity.userName || 'User'} />
                             <AvatarFallback className="rounded-none">{(activity.userName || 'U').slice(0,2).toUpperCase()}</AvatarFallback>
                           </Avatar>
-                          <span className="font-semibold text-gray-900">{activity.userName || 'Unknown User'}</span>
-                          <span className="text-gray-700 capitalize">{activity.activityType.replace('_', ' ')}</span>
+                          <div className="flex flex-col leading-tight">
+                            <span className="font-semibold text-gray-900">{activity.userName || 'Unknown User'}</span>
+                            <span className="text-gray-600 capitalize">{activity.activityType.replace('_', ' ')}</span>
+                          </div>
                         </div>
                         <span className="text-gray-500">{format(new Date(activity.createdAt as any), 'MMM d, h:mm a')}</span>
                       </div>

--- a/frontend/src/components/admission-details-modal.tsx
+++ b/frontend/src/components/admission-details-modal.tsx
@@ -334,7 +334,7 @@ export function AdmissionDetailsModal({ open, onOpenChange, admission, onOpenStu
           </div>
 
           {/* Right Sidebar - Activity Timeline */}
-          <div className="w-[360px] border-l bg-white flex flex-col min-h-0 pt-5 lg:pt-0 max-[991px]:pt-5">
+          <div className="w-[420px] border-l bg-white flex flex-col min-h-0 pt-5 lg:pt-0 max-[991px]:pt-5">
             <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white">
               <div className="flex items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-gray-900" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/application-details-modal-new.tsx
+++ b/frontend/src/components/application-details-modal-new.tsx
@@ -467,7 +467,7 @@ export function ApplicationDetailsModal({ open, onOpenChange, application, onOpe
             </div>
           </div>
 
-          <div className="w-[360px] flex-shrink-0 bg-white border-l p-3 flex flex-col min-h-0">
+          <div className="w-[420px] flex-shrink-0 bg-white border-l p-3 flex flex-col min-h-0">
             <div className="sticky top-0 z-10 px-1 pb-2 bg-white">
               <div className="flex items-center gap-2">
                 <Calendar className="w-5 h-5" />

--- a/frontend/src/components/application-details-modal.tsx
+++ b/frontend/src/components/application-details-modal.tsx
@@ -315,7 +315,7 @@ export function ApplicationDetailsModal({ open, onOpenChange, application, onOpe
           </div>
 
           {/* Right Sidebar - Activity Timeline */}
-          <div className="w-[360px] border-l bg-white flex flex-col min-h-0 pt-5 lg:pt-0 max-[991px]:pt-5">
+          <div className="w-[420px] border-l bg-white flex flex-col min-h-0 pt-5 lg:pt-0 max-[991px]:pt-5">
             <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white">
               <div className="flex items-center gap-2">
                 <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-gray-900" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/lead-details-modal.tsx
+++ b/frontend/src/components/lead-details-modal.tsx
@@ -544,13 +544,13 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
 
             {/* Right: Timeline */}
             <div className="border-l bg-white flex flex-col min-h-0">
-              <div className="sticky top-0 z-10 px-3 py-2 border-b bg-white flex items-center justify-between">
-                <h2 className="text-xs font-semibold">Activity Timeline</h2>
+              <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white flex items-center justify-between">
+                <h2 className="text-sm font-semibold">Activity Timeline</h2>
                 <Button size="sm" className="bg-blue-600 hover:bg-blue-700 text-white" onClick={() => window.dispatchEvent(new CustomEvent('open-activity-composer', { detail: { entityType: 'lead', entityId: lead.id } }))}>
                   + Add Activity
                 </Button>
               </div>
-              <div className="flex-1 overflow-y-auto pt-1 min-h-0">
+              <div className="flex-1 overflow-y-auto pt-2 min-h-0">
                 <ActivityTracker entityType="lead" entityId={lead.id} entityName={lead.name} />
               </div>
             </div>

--- a/frontend/src/components/lead-details-modal.tsx
+++ b/frontend/src/components/lead-details-modal.tsx
@@ -220,7 +220,7 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
               {/* Sticky header inside scroll context */}
               <div className="sticky top-0 z-20">
                 {/* Blue title bar */}
-                <div className="px-4 py-3 bg-blue-800 text-white flex items-center justify-between rounded-t-xl">
+                <div className="px-4 py-3 bg-[#223E7D] text-white flex items-center justify-between w-full">
                   <div>
                     <div className="text-[12px] opacity-80">Lead</div>
                     <div className="text-base sm:text-lg font-semibold leading-tight truncate max-w-[60vw]">{lead.name || 'Lead'}</div>
@@ -237,7 +237,7 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
                           <Button
                             variant="outline"
                             size="sm"
-                            className="bg-white text-blue-800 hover:bg-white/90"
+                            className="bg-white text-primary hover:bg-white/90"
                             onClick={() => { onOpenChange(false); setLocation(`/students?studentId=${convertedStudent.id}`); }}
                           >
                             View Student
@@ -246,7 +246,7 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
                           <Button
                             variant="outline"
                             size="sm"
-                            className="bg-white text-blue-800 hover:bg-white/90"
+                            className="bg-white text-primary hover:bg-white/90"
                             onClick={() => {
                               try { onOpenChange(false); } catch {}
                               if (typeof onOpenConvert === 'function') onOpenConvert(lead); else setLocation(`/leads/${lead?.id}/student`);
@@ -546,7 +546,7 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
             <div className="border-l bg-white flex flex-col min-h-0">
               <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white flex items-center justify-between">
                 <h2 className="text-sm font-semibold">Activity Timeline</h2>
-                <Button size="sm" className="bg-blue-600 hover:bg-blue-700 text-white" onClick={() => window.dispatchEvent(new CustomEvent('open-activity-composer', { detail: { entityType: 'lead', entityId: lead.id } }))}>
+                <Button size="sm" className="bg-primary hover:bg-primary/90 text-primary-foreground" onClick={() => window.dispatchEvent(new CustomEvent('open-activity-composer', { detail: { entityType: 'lead', entityId: lead.id } }))}>
                   + Add Activity
                 </Button>
               </div>

--- a/frontend/src/components/lead-details-modal.tsx
+++ b/frontend/src/components/lead-details-modal.tsx
@@ -222,8 +222,7 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
                 {/* Blue title bar */}
                 <div className="px-4 py-3 bg-[#223E7D] text-white flex items-center justify-between w-full">
                   <div>
-                    <div className="text-[12px] opacity-80">Lead</div>
-                    <div className="text-base sm:text-lg font-semibold leading-tight truncate max-w-[60vw]">{lead.name || 'Lead'}</div>
+                    <div className="text-base sm:text-lg font-semibold leading-tight truncate max-w-[720px]">{lead.name || 'Lead'}</div>
                   </div>
                   <div className="flex items-center gap-2">
                     {convertedLoading ? (
@@ -544,13 +543,7 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
 
             {/* Right: Timeline */}
             <div className="border-l bg-white flex flex-col min-h-0">
-              <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white flex items-center justify-between">
-                <h2 className="text-sm font-semibold">Activity Timeline</h2>
-                <Button size="sm" className="bg-primary hover:bg-primary/90 text-primary-foreground" onClick={() => window.dispatchEvent(new CustomEvent('open-activity-composer', { detail: { entityType: 'lead', entityId: lead.id } }))}>
-                  + Add Activity
-                </Button>
-              </div>
-              <div className="flex-1 overflow-y-auto pt-2 min-h-0">
+              <div className="flex-1 overflow-y-auto pt-2 min-h-0 mt-7">
                 <ActivityTracker entityType="lead" entityId={lead.id} entityName={lead.name} />
               </div>
             </div>

--- a/frontend/src/components/student-details-modal.tsx
+++ b/frontend/src/components/student-details-modal.tsx
@@ -261,7 +261,7 @@ export function StudentDetailsModal({ open, onOpenChange, student, onStudentUpda
           </div>
 
           {/* Right: Timeline */}
-          <div className="w-[360px] border-l bg-white flex flex-col min-h-0">
+          <div className="w-[420px] border-l bg-white flex flex-col min-h-0">
             <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white">
               <h2 className="text-sm font-semibold">Activity Timeline</h2>
             </div>

--- a/frontend/src/components/student-profile-modal-new.tsx
+++ b/frontend/src/components/student-profile-modal-new.tsx
@@ -391,7 +391,7 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAppli
               </div>
             </div>
 
-            <div className="grid grid-cols-[1fr_360px] flex-1 min-h-0">
+            <div className="grid grid-cols-[1fr_420px] flex-1 min-h-0">
               {/* Left: Content */}
               <div className="flex flex-col min-h-0">
 

--- a/frontend/src/components/student-profile-modal.tsx
+++ b/frontend/src/components/student-profile-modal.tsx
@@ -108,7 +108,7 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAddAp
         <DialogContent className="no-not-allowed max-w-6xl w-[95vw] max-h-[90vh] overflow-hidden p-0">
           <DialogTitle className="sr-only">Student Profile</DialogTitle>
 
-          <div className="grid grid-cols-[1fr_360px] h-[90vh] min-h-0">
+          <div className="grid grid-cols-[1fr_420px] h-[90vh] min-h-0">
             {/* Left: Content */}
             <div className="flex flex-col min-h-0">
               {/* Sticky header inside scroll context */}


### PR DESCRIPTION
## Purpose

Based on the conversation, the user wanted to:
- Move type comments/activity info below the name in the activity tracker
- Copy header settings, activity width, and design consistency from `/students/:id` to `/leads/:id`
- Fix header stretching issues in `/leads/:id` and match button colors from student details

## Code changes

**Activity Tracker Layout:**
- Restructured activity items to display username above activity type in a vertical flex layout
- Changed activity type text color from `text-gray-700` to `text-gray-600`

**Lead Details Modal Header:**
- Updated header background color to match student modal (`bg-[#223E7D]`)
- Removed "Lead" label and simplified header to show only the lead name
- Fixed header width to stretch fully (`w-full`)
- Updated button colors to use `text-primary` instead of `text-blue-800`
- Removed activity timeline header section for cleaner layout

**Activity Sidebar Width Standardization:**
- Increased activity sidebar width from `360px` to `420px` across all detail modals:
  - Student details modal
  - Application details modal
  - Admission details modal
  - Student profile modal

These changes ensure consistent design and layout across all entity detail modals while improving the visual hierarchy of activity information.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 68`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8d119919201c407ab4997c3bc020d76a/vibe-hub)

👀 [Preview Link](https://8d119919201c407ab4997c3bc020d76a-vibe-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8d119919201c407ab4997c3bc020d76a</projectId>-->
<!--<branchName>vibe-hub</branchName>-->