### PR TITLE
Update login colors and create reusable details dialog

### DIFF
--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -149,7 +149,7 @@ export function Sidebar() {
               <GraduationCap className="text-white" size={16} />
             </div>
             <div>
-              <h1 className="text-sm font-bold">SetCrm</h1>
+              <h1 className="text-sm font-bold">SetCRM</h1>
               <p className="text-[10px] text-white/70">Consultancy</p>
             </div>
           </div>

--- a/frontend/src/components/student-details-modal.tsx
+++ b/frontend/src/components/student-details-modal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { DetailsDialogLayout } from '@/components/ui/details-dialog';
 console.log('[modal] loaded: frontend/src/components/student-details-modal.tsx');
 import * as DropdownsService from '@/services/dropdowns';
 import { Button } from '@/components/ui/button';
@@ -115,162 +115,153 @@ export function StudentDetailsModal({ open, onOpenChange, student, onStudentUpda
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="no-not-allowed max-w-6xl w-[95vw] max-h-[90vh] overflow-hidden p-0">
-        <DialogTitle className="sr-only">Student Details</DialogTitle>
-
-        <div className="grid grid-cols-[1fr_360px] h-[90vh] min-h-0">
-          {/* Left: Content */}
-          <div className="flex flex-col min-h-0">
-            {/* Sticky header inside scroll context */}
-            <div className="sticky top-0 z-20 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/60">
-              <div className="px-4 py-3 flex items-center justify-between">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center shrink-0">
-                    <UserIcon className="w-5 h-5 text-primary" />
-                  </div>
-                  <h1 className="text-lg font-semibold truncate">{student.name}</h1>
-                </div>
-                <div className="flex items-center gap-2">
-                  {isEditing ? (
-                    <>
-                      <Button variant="default" size="xs" className="rounded-full px-2 [&_svg]:size-3 bg-primary text-primary-foreground hover:bg-primary/90" onClick={handleSaveChanges} title="Save" disabled={updateStudentMutation.isPending}>
-                        <Save />
-                        <span className="hidden lg:inline">{updateStudentMutation.isPending ? 'Saving…' : 'Save'}</span>
-                      </Button>
-                      <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => { setIsEditing(false); setEditData(student); }} title="Cancel" disabled={updateStudentMutation.isPending}>
-                        <X />
-                        <span className="hidden lg:inline">Cancel</span>
-                      </Button>
-                    </>
-                  ) : (
-                    <>
-                      <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => setIsEditing(true)} title="Edit">
-                        <Edit />
-                        <span className="hidden lg:inline">Edit</span>
-                      </Button>
-                      <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => {
-                      try {
-                        const { useModalManager } = require('@/contexts/ModalManagerContext');
-                        const { openModal } = useModalManager();
-                        openModal(() => setLocation(`/applications/add?studentId=${student.id}`));
-                      } catch {
-                        setLocation(`/applications/add?studentId=${student.id}`);
-                      }
-                    }} title="Add Application">
-                        <Plus />
-                        <span className="hidden lg:inline">Add App</span>
-                      </Button>
-                    </>
-                  )}
-                  <Button variant="ghost" size="icon" className="rounded-full w-8 h-8" onClick={() => onOpenChange(false)}>
-                    <X className="w-4 h-4" />
-                  </Button>
-                </div>
-              </div>
-
-              {statusSequence.length > 0 && (
-                <div className="px-4 pb-3">
-                  <div className="w-full bg-gray-100 rounded-md p-1.5">
-                    <div className="flex items-center justify-between relative">
-                      {statusSequence.map((statusId, index) => {
-                        const currentIndex = statusSequence.indexOf(currentStatus);
-                        const isCompleted = index <= currentIndex;
-                        const statusName = getStatusDisplayName(statusId);
-                        const handleClick = () => {
-                          if (statusUpdateMutation.isPending) return;
-                          if (currentStatus === statusId) return;
-                          statusUpdateMutation.mutate(statusId);
-                        };
-                        return (
-                          <div key={statusId} className="flex flex-col items-center relative flex-1 cursor-pointer select-none" onClick={handleClick} role="button" aria-label={`Set status to ${statusName}`}>
-                            <div className={`w-5 h-5 rounded-full border flex items-center justify-center transition-all ${isCompleted ? 'bg-green-500 border-green-500 text-white' : 'bg-white border-gray-300 text-gray-500 hover:border-green-500'}`}>
-                              {isCompleted ? <div className="w-1.5 h-1.5 bg-white rounded-full" /> : <div className="w-1.5 h-1.5 bg-gray-300 rounded-full" />}
-                            </div>
-                            <span className={`mt-1 text-xs font-medium text-center ${isCompleted ? 'text-green-600' : 'text-gray-600 hover:text-green-600'}`}>{statusName}</span>
-                            {index < statusSequence.length - 1 && (
-                              <div className={`absolute top-2.5 left-1/2 w-full h-0.5 transform -translate-y-1/2 ${index < currentIndex ? 'bg-green-500' : 'bg-gray-300'}`} style={{ marginLeft: '0.625rem', width: 'calc(100% - 1.25rem)' }} />
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Scrollable body */}
-            <div className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
-              <Card className="w-full shadow-md border border-gray-200 bg-white">
-                <CardHeader className="pb-3">
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-sm">Personal Information</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="name" className="flex items-center space-x-2"><UserIcon className="w-4 h-4" /><span>Full Name</span></Label>
-                      <Input id="name" value={editData.name || ''} onChange={(e) => setEditData({ ...editData, name: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="email" className="flex items-center space-x-2"><Mail className="w-4 h-4" /><span>Email Address</span></Label>
-                      <Input id="email" type="email" value={editData.email || ''} onChange={(e) => setEditData({ ...editData, email: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="phone" className="flex items-center space-x-2"><Phone className="w-4 h-4" /><span>Phone Number</span></Label>
-                      <Input id="phone" type="tel" value={editData.phone || ''} onChange={(e) => setEditData({ ...editData, phone: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="dateOfBirth" className="flex items-center space-x-2"><CalendarIcon className="w-4 h-4" /><span>Date of Birth</span></Label>
-                      <Input id="dateOfBirth" type="date" value={(editData.dateOfBirth as any) || ''} onChange={(e) => setEditData({ ...editData, dateOfBirth: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
-                    </div>
-                    <div className="space-y-2">
-                      <Label className="flex items-center space-x-2"><span>Counsellor</span></Label>
-                      <Select value={editData.counselorId || ''} onValueChange={(value) => setEditData({ ...editData, counselorId: value })} disabled={!isEditing || updateStudentMutation.isPending}>
-                        <SelectTrigger className="h-8 text-xs shadow-sm border border-gray-300 bg-white"><SelectValue placeholder="Select counsellor" /></SelectTrigger>
-                        <SelectContent>
-                          {(users as any[]).map((u: User) => (
-                            <SelectItem key={u.id} value={u.id}>{(u.firstName || '') + ' ' + (u.lastName || '')} ({u.email})</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <CollapsibleCard persistKey={`student-details:modal:${student.id}:student-information`} header={<CardTitle className="text-sm flex items-center space-x-2"><Award className="w-5 h-5 text-primary" /><span>Student Information</span></CardTitle>} cardClassName="shadow-md border border-gray-200 bg-white">
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                  <div className="space-y-2">
-                    <Label className="flex items-center space-x-2"><Globe className="w-4 h-4" /><span>Target Country</span></Label>
-                    <Input value={(editData.targetCountry as any) || ''} onChange={(e) => setEditData({ ...editData, targetCountry: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="flex items-center space-x-2"><BookOpen className="w-4 h-4" /><span>Target Program</span></Label>
-                    <Input value={(editData.targetProgram as any) || ''} onChange={(e) => setEditData({ ...editData, targetProgram: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="flex items-center space-x-2"><MapPin className="w-4 h-4" /><span>Address</span></Label>
-                    <Input value={(editData.address as any) || ''} onChange={(e) => setEditData({ ...editData, address: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
-                  </div>
-                </div>
-              </CollapsibleCard>
-            </div>
+    <DetailsDialogLayout
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Student Details"
+      headerLeft={(
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center shrink-0">
+            <UserIcon className="w-5 h-5 text-primary" />
           </div>
-
-          {/* Right: Timeline */}
-          <div className="w-[420px] border-l bg-white flex flex-col min-h-0">
-            <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white">
-              <h2 className="text-sm font-semibold">Activity Timeline</h2>
-            </div>
-            <div className="flex-1 overflow-y-auto pt-2 min-h-0">
-              <ActivityTracker entityType="student" entityId={student.id} entityName={student.name} />
-            </div>
+          <h1 className="text-lg font-semibold truncate">{student.name}</h1>
+        </div>
+      )}
+      headerRight={(
+        <div className="flex items-center gap-2">
+          {isEditing ? (
+            <>
+              <Button variant="default" size="xs" className="rounded-full px-2 [&_svg]:size-3 bg-primary text-primary-foreground hover:bg-primary/90" onClick={handleSaveChanges} title="Save" disabled={updateStudentMutation.isPending}>
+                <Save />
+                <span className="hidden lg:inline">{updateStudentMutation.isPending ? 'Saving…' : 'Save'}</span>
+              </Button>
+              <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => { setIsEditing(false); setEditData(student); }} title="Cancel" disabled={updateStudentMutation.isPending}>
+                <X />
+                <span className="hidden lg:inline">Cancel</span>
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => setIsEditing(true)} title="Edit">
+                <Edit />
+                <span className="hidden lg:inline">Edit</span>
+              </Button>
+              <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => {
+                try {
+                  const { useModalManager } = require('@/contexts/ModalManagerContext');
+                  const { openModal } = useModalManager();
+                  openModal(() => setLocation(`/applications/add?studentId=${student.id}`));
+                } catch {
+                  setLocation(`/applications/add?studentId=${student.id}`);
+                }
+              }} title="Add Application">
+                <Plus />
+                <span className="hidden lg:inline">Add App</span>
+              </Button>
+              <Button variant="ghost" size="icon" className="rounded-full w-8 h-8" onClick={() => onOpenChange(false)}>
+                <X className="w-4 h-4" />
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+      statusBar={statusSequence.length > 0 ? (
+        <div className="w-full bg-gray-100 rounded-md p-1.5">
+          <div className="flex items-center justify-between relative">
+            {statusSequence.map((statusId, index) => {
+              const currentIndex = statusSequence.indexOf(currentStatus);
+              const isCompleted = index <= currentIndex;
+              const statusName = getStatusDisplayName(statusId);
+              const handleClick = () => {
+                if (statusUpdateMutation.isPending) return;
+                if (currentStatus === statusId) return;
+                statusUpdateMutation.mutate(statusId);
+              };
+              return (
+                <div key={statusId} className="flex flex-col items-center relative flex-1 cursor-pointer select-none" onClick={handleClick} role="button" aria-label={`Set status to ${statusName}`}>
+                  <div className={`w-5 h-5 rounded-full border flex items-center justify-center transition-all ${isCompleted ? 'bg-green-500 border-green-500 text-white' : 'bg-white border-gray-300 text-gray-500 hover:border-green-500'}`}>
+                    {isCompleted ? <div className="w-1.5 h-1.5 bg-white rounded-full" /> : <div className="w-1.5 h-1.5 bg-gray-300 rounded-full" />}
+                  </div>
+                  <span className={`mt-1 text-xs font-medium text-center ${isCompleted ? 'text-green-600' : 'text-gray-600 hover:text-green-600'}`}>{statusName}</span>
+                  {index < statusSequence.length - 1 && (
+                    <div className={`absolute top-2.5 left-1/2 w-full h-0.5 transform -translate-y-1/2 ${index < currentIndex ? 'bg-green-500' : 'bg-gray-300'}`} style={{ marginLeft: '0.625rem', width: 'calc(100% - 1.25rem)' }} />
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      ) : undefined}
+      leftContent={(
+        <>
+          <Card className="w-full shadow-md border border-gray-200 bg-white">
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-sm">Personal Information</CardTitle>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                <div className="space-y-2">
+                  <Label htmlFor="name" className="flex items-center space-x-2"><UserIcon className="w-4 h-4" /><span>Full Name</span></Label>
+                  <Input id="name" value={editData.name || ''} onChange={(e) => setEditData({ ...editData, name: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="email" className="flex items-center space-x-2"><Mail className="w-4 h-4" /><span>Email Address</span></Label>
+                  <Input id="email" type="email" value={editData.email || ''} onChange={(e) => setEditData({ ...editData, email: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="phone" className="flex items-center space-x-2"><Phone className="w-4 h-4" /><span>Phone Number</span></Label>
+                  <Input id="phone" type="tel" value={editData.phone || ''} onChange={(e) => setEditData({ ...editData, phone: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="dateOfBirth" className="flex items-center space-x-2"><CalendarIcon className="w-4 h-4" /><span>Date of Birth</span></Label>
+                  <Input id="dateOfBirth" type="date" value={(editData.dateOfBirth as any) || ''} onChange={(e) => setEditData({ ...editData, dateOfBirth: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
+                </div>
+                <div className="space-y-2">
+                  <Label className="flex items-center space-x-2"><span>Counsellor</span></Label>
+                  <Select value={editData.counselorId || ''} onValueChange={(value) => setEditData({ ...editData, counselorId: value })} disabled={!isEditing || updateStudentMutation.isPending}>
+                    <SelectTrigger className="h-8 text-xs shadow-sm border border-gray-300 bg-white"><SelectValue placeholder="Select counsellor" /></SelectTrigger>
+                    <SelectContent>
+                      {(users as any[]).map((u: User) => (
+                        <SelectItem key={u.id} value={u.id}>{(u.firstName || '') + ' ' + (u.lastName || '')} ({u.email})</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <CollapsibleCard persistKey={`student-details:modal:${student.id}:student-information`} header={<CardTitle className="text-sm flex items-center space-x-2"><Award className="w-5 h-5 text-primary" /><span>Student Information</span></CardTitle>} cardClassName="shadow-md border border-gray-200 bg-white">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+              <div className="space-y-2">
+                <Label className="flex items-center space-x-2"><Globe className="w-4 h-4" /><span>Target Country</span></Label>
+                <Input value={(editData.targetCountry as any) || ''} onChange={(e) => setEditData({ ...editData, targetCountry: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
+              </div>
+              <div className="space-y-2">
+                <Label className="flex items-center space-x-2"><BookOpen className="w-4 h-4" /><span>Target Program</span></Label>
+                <Input value={(editData.targetProgram as any) || ''} onChange={(e) => setEditData({ ...editData, targetProgram: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
+              </div>
+              <div className="space-y-2">
+                <Label className="flex items-center space-x-2"><MapPin className="w-4 h-4" /><span>Address</span></Label>
+                <Input value={(editData.address as any) || ''} onChange={(e) => setEditData({ ...editData, address: e.target.value })} disabled={!isEditing || updateStudentMutation.isPending} className="h-8 text-xs shadow-sm border border-gray-300 bg-white" />
+              </div>
+            </div>
+          </CollapsibleCard>
+        </>
+      )}
+      rightContent={(
+        <>
+          <div className="sticky top-0 z-10 px-4 py-3 border-b bg-white">
+            <h2 className="text-sm font-semibold">Activity Timeline</h2>
+          </div>
+          <div className="pt-2">
+            <ActivityTracker entityType="student" entityId={student.id} entityName={student.name} />
+          </div>
+        </>
+      )}
+      rightWidthClassName="w-[420px]"
+    />
   );
 }

--- a/frontend/src/components/student-profile-modal-new.tsx
+++ b/frontend/src/components/student-profile-modal-new.tsx
@@ -334,280 +334,267 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAppli
 
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent hideClose className="no-not-allowed max-w-6xl w-[95vw] max-h-[90vh] overflow-hidden p-0 rounded-xl shadow-xl">
-          <DialogTitle className="sr-only">Student Profile</DialogTitle>
-          
-          <div className="flex flex-col h-[90vh] min-h-0 bg-[#EDEDED]">
-            {/* Global sticky header spanning both columns */}
-            <div className="sticky top-0 z-20">
-              <div className="px-4 py-3 bg-[#223E7D] text-white flex items-center justify-between rounded-t-xl">
-                <div>
-                  <div className="text-base sm:text-lg font-semibold leading-tight truncate max-w-[60vw]">{student?.name || 'Student'}</div>
+      <DetailsDialogLayout
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Student Profile"
+        headerClassName="bg-[#223E7D] text-white"
+        statusBarWrapperClassName="px-4 py-2 bg-[#223E7D] text-white -mt-px"
+        headerLeft={(
+          <div className="text-base sm:text-lg font-semibold leading-tight truncate max-w-[60vw]">{student?.name || 'Student'}</div>
+        )}
+        headerRight={(
+          <div className="flex items-center gap-2">
+            {!isEditing ? (
+              <>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  className="px-3 [&_svg]:size-3 bg-white text-black hover:bg-gray-100 border border-gray-300 rounded-md"
+                  onClick={() => { try { setLocation(`/students/${student?.id}/application`); } catch {} onOpenChange(false); if (typeof onOpenAddApplication === 'function') { setTimeout(() => onOpenAddApplication(student?.id), 160); } }}
+                  title="Add Application"
+                >
+                  <Plus />
+                  <span>Add Application</span>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  className="px-3 [&_svg]:size-3 bg-white text-black hover:bg-gray-100 border border-gray-300 rounded-md"
+                  onClick={() => { setIsEditing(true); try { setLocation(`/students/${student?.id}/edit`); } catch {} }}
+                  disabled={isLoading}
+                  title="Edit"
+                >
+                  <Edit />
+                  <span>Edit</span>
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button size="xs" onClick={handleSaveChanges} disabled={updateStudentMutation.isPending} title="Save Changes" className="bg-[#0071B0] hover:bg-[#00649D] text-white">
+                  <Save className="w-3.5 h-3.5 mr-1" />
+                  <span>Save Changes</span>
+                </Button>
+                <Button variant="outline" size="xs" onClick={() => { setIsEditing(false); setEditData(student); try { setLocation(`/students/${student?.id}`); } catch {} }} title="Cancel" className="bg-white text-[#223E7D] hover:bg-white/90 border border-white">
+                  <X className="w-3.5 h-3.5 mr-1" />
+                  <span>Cancel</span>
+                </Button>
+              </>
+            )}
+            <Button variant="ghost" size="icon" className="rounded-full w-8 h-8 bg-white text-[#223E7D] hover:bg-white/90" onClick={() => onOpenChange(false)}>
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+        )}
+        statusBar={statusSequence.length > 0 ? <StatusProgressBar /> : undefined}
+        leftContent={(
+          <>
+            <Card className="w-full shadow-sm hover:shadow-md transition-shadow">
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between">
+                  <CardTitle>Student Information</CardTitle>
+                  <div className="flex items-center space-x-2"></div>
                 </div>
-                <div className="flex items-center gap-2">
-                  {!isEditing ? (
-                    <>
-                      <Button
-                        variant="outline"
-                        size="xs"
-                        className="px-3 [&_svg]:size-3 bg-white text-black hover:bg-gray-100 border border-gray-300 rounded-md"
-                        onClick={() => { try { setLocation(`/students/${student?.id}/application`); } catch {} onOpenChange(false); if (typeof onOpenAddApplication === 'function') { setTimeout(() => onOpenAddApplication(student?.id), 160); } }}
-                        title="Add Application"
-                      >
-                        <Plus />
-                        <span>Add Application</span>
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="xs"
-                        className="px-3 [&_svg]:size-3 bg-white text-black hover:bg-gray-100 border border-gray-300 rounded-md"
-                        onClick={() => { setIsEditing(true); try { setLocation(`/students/${student?.id}/edit`); } catch {} }}
-                        disabled={isLoading}
-                        title="Edit"
-                      >
-                        <Edit />
-                        <span>Edit</span>
-                      </Button>
-                    </>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                  <div className="space-y-2">
+                    <Label className="flex items-center space-x-2"><span>Student ID</span></Label>
+                    <div className="text-sm text-gray-700">{student?.student_id || student?.id || 'N/A'}</div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="name" className="flex items-center space-x-2">
+                      <UserIcon className="w-4 h-4" />
+                      <span>Full Name</span>
+                    </Label>
+                    <Input id="name" value={isEditing ? (editData.name || '') : (student?.name || '')} onChange={(e) => setEditData({ ...editData, name: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="passportNumber" className="flex items-center space-x-2">
+                      <UserIcon className="w-4 h-4" />
+                      <span>Passport Number</span>
+                    </Label>
+                    <Input id="passportNumber" value={isEditing ? (editData.passportNumber || '') : (student?.passportNumber || '')} onChange={(e) => setEditData({ ...editData, passportNumber: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="email" className="flex items-center space-x-2">
+                      <Mail className="w-4 h-4" />
+                      <span>Email Address</span>
+                    </Label>
+                    <Input id="email" type="email" value={isEditing ? (editData.email || '') : (student?.email || '')} onChange={(e) => setEditData({ ...editData, email: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="phone" className="flex items-center space-x-2">
+                      <Phone className="w-4 h-4" />
+                      <span>Phone Number</span>
+                    </Label>
+                    <Input id="phone" type="tel" value={isEditing ? (editData.phone || '') : (student?.phone || '')} onChange={(e) => setEditData({ ...editData, phone: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="dateOfBirth" className="flex items-center space-x-2">
+                      <Calendar className="w-4 h-4" />
+                      <span>Date of Birth</span>
+                    </Label>
+                    <DobPicker id="dateOfBirth" value={isEditing ? (editData.dateOfBirth || '') : (student?.dateOfBirth || '')} onChange={(v) => setEditData({ ...editData, dateOfBirth: v })} disabled={!isEditing} />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="address" className="flex items-center space-x-2">
+                      <MapPin className="w-4 h-4" />
+                      <span>Address</span>
+                    </Label>
+                    <Textarea id="address" rows={3} value={isEditing ? (editData.address || '') : (student?.address || '')} onChange={(e) => setEditData({ ...editData, address: e.target.value })} disabled={!isEditing} className="text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <CollapsibleCard persistKey={`student-details:${authUser?.id || 'anon'}:academic-information`} cardClassName="shadow-sm hover:shadow-md transition-shadow" header={<CardTitle className="flex items-center space-x-2"><GraduationCap className="w-4 h-4 text-primary" /><span>Academic Information</span></CardTitle>}>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                <div className="space-y-2">
+                  <Label htmlFor="englishProficiency" className="flex items-center space-x-2">
+                    <FileText className="w-4 h-4" />
+                    <span>English Proficiency</span>
+                  </Label>
+                  {isEditing ? (
+                    <Select value={editData.englishProficiency || ''} onValueChange={(v) => setEditData({ ...editData, englishProficiency: v })}>
+                      <SelectTrigger className="h-7 text-[11px]"><SelectValue placeholder="Select proficiency" /></SelectTrigger>
+                      <SelectContent>
+                        {getFieldOptions('englishProficiency').map((opt: any) => (
+                          <SelectItem key={opt.key || opt.id || opt.value} value={(opt.key || opt.id || opt.value) as string}>
+                            {opt.value}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   ) : (
-                    <>
-                      <Button size="xs" onClick={handleSaveChanges} disabled={updateStudentMutation.isPending} title="Save Changes" className="bg-[#0071B0] hover:bg-[#00649D] text-white">
-                        <Save className="w-3.5 h-3.5 mr-1" />
-                        <span>Save Changes</span>
-                      </Button>
-                      <Button variant="outline" size="xs" onClick={() => { setIsEditing(false); setEditData(student); try { setLocation(`/students/${student?.id}`); } catch {} }} title="Cancel" className="bg-white text-[#223E7D] hover:bg-white/90 border border-white">
-                        <X className="w-3.5 h-3.5 mr-1" />
-                        <span>Cancel</span>
-                      </Button>
-                    </>
+                    <Input id="englishProficiency" value={getDropdownLabel('englishProficiency', student?.englishProficiency || '')} disabled className="h-7 text-[11px]" />
                   )}
-                  <Button variant="ghost" size="icon" className="rounded-full w-8 h-8 bg-white text-[#223E7D] hover:bg-white/90" onClick={() => onOpenChange(false)}>
-                    <X className="w-4 h-4" />
+                </div>
+
+                <div className="space-y-2">
+                  <Label className="flex items-center space-x-2"><span>Counsellor</span></Label>
+                  {isEditing ? (
+                    <Select value={editData.counselorId || ''} onValueChange={(value) => setEditData({ ...editData, counselorId: value })}>
+                      <SelectTrigger className="h-7 text-[11px]"><SelectValue placeholder="Select counsellor" /></SelectTrigger>
+                      <SelectContent>
+                        {counselorOptions().map((opt: any) => (
+                          <SelectItem key={opt.id} value={opt.id}>{opt.value}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <div className="text-sm text-gray-700">{(() => { const found = counselorOptions().find((d: any) => d.id === student?.counselorId); return found?.value || 'Unassigned'; })()}</div>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label className="flex items-center space-x-2"><span>Expectation</span></Label>
+                  {isEditing ? (
+                    <Select value={editData.expectation || ''} onValueChange={(v) => setEditData({ ...editData, expectation: v })}>
+                      <SelectTrigger className="h-7 text-[11px]"><SelectValue placeholder="Select expectation" /></SelectTrigger>
+                      <SelectContent>
+                        {getFieldOptions('expectation').map((opt: any) => (
+                          <SelectItem key={opt.key || opt.id || opt.value} value={(opt.key || opt.id || opt.value) as string}>
+                            {opt.value}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <Input value={getDropdownLabel('expectation', student?.expectation || '')} disabled className="h-7 text-[11px]" />
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  {isEditing ? (
+                    <div className="flex items-center space-x-6">
+                      <div className="flex items-center space-x-3">
+                        <Checkbox checked={!!editData.consultancyFree} onCheckedChange={(v) => setEditData({ ...editData, consultancyFree: !!v })} />
+                        <span className="text-sm">Consultancy Free</span>
+                      </div>
+                      <div className="flex items-center space-x-3">
+                        <Checkbox checked={!!editData.scholarship} onCheckedChange={(v) => setEditData({ ...editData, scholarship: !!v })} />
+                        <span className="text-sm">Scholarship</span>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <div className="text-[11px] text-gray-600">Consultancy Fee</div>
+                        <div className="text-sm text-gray-700">{student?.consultancyFree ? 'Yes' : 'No'}</div>
+                      </div>
+                      <div>
+                        <div className="text-[11px] text-gray-600">Scholarship</div>
+                        <div className="text-sm text-gray-700">{student?.scholarship ? 'Yes' : 'No'}</div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+              </div>
+            </CollapsibleCard>
+
+            <CollapsibleCard
+              persistKey={`student-details:${authUser?.id || 'anon'}:applications`}
+              cardClassName="shadow-sm hover:shadow-md transition-shadow"
+              header={
+                <div className="flex items-center justify-between w-full">
+                  <CardTitle className="flex items-center space-x-2">
+                    <FileText className="w-4 h-4 text-primary" />
+                    <span>Applications</span>
+                    {Array.isArray(applications) && (
+                      <Badge variant="secondary" className="ml-2 text-[10px]">{applications.length}</Badge>
+                    )}
+                  </CardTitle>
+                  <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => { onOpenChange(false); if (typeof onOpenAddApplication === 'function') { setTimeout(() => onOpenAddApplication(student?.id), 160); } }}>
+                    <Plus />
+                    <span>Add Application</span>
                   </Button>
                 </div>
-              </div>
-              <div className="px-4 py-2 bg-[#223E7D] text-white -mt-px">
-                {statusSequence.length > 0 && <StatusProgressBar />}
-              </div>
-            </div>
-
-            <div className="grid grid-cols-[1fr_420px] flex-1 min-h-0">
-              {/* Left: Content */}
-              <div className="flex flex-col min-h-0">
-
-              {/* Scrollable body */}
-              <div className="flex-1 overflow-y-auto p-3 space-y-3 min-h-0">
-                <Card className="w-full shadow-sm hover:shadow-md transition-shadow">
-                  <CardHeader className="pb-2">
-                    <div className="flex items-center justify-between">
-                      <CardTitle>Student Information</CardTitle>
-                      <div className="flex items-center space-x-2"></div>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                      <div className="space-y-2">
-                        <Label className="flex items-center space-x-2"><span>Student ID</span></Label>
-                        <div className="text-sm text-gray-700">{student?.student_id || student?.id || 'N/A'}</div>
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="name" className="flex items-center space-x-2">
-                          <UserIcon className="w-4 h-4" />
-                          <span>Full Name</span>
-                        </Label>
-                        <Input id="name" value={isEditing ? (editData.name || '') : (student?.name || '')} onChange={(e) => setEditData({ ...editData, name: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="passportNumber" className="flex items-center space-x-2">
-                          <UserIcon className="w-4 h-4" />
-                          <span>Passport Number</span>
-                        </Label>
-                        <Input id="passportNumber" value={isEditing ? (editData.passportNumber || '') : (student?.passportNumber || '')} onChange={(e) => setEditData({ ...editData, passportNumber: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="email" className="flex items-center space-x-2">
-                          <Mail className="w-4 h-4" />
-                          <span>Email Address</span>
-                        </Label>
-                        <Input id="email" type="email" value={isEditing ? (editData.email || '') : (student?.email || '')} onChange={(e) => setEditData({ ...editData, email: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="phone" className="flex items-center space-x-2">
-                          <Phone className="w-4 h-4" />
-                          <span>Phone Number</span>
-                        </Label>
-                        <Input id="phone" type="tel" value={isEditing ? (editData.phone || '') : (student?.phone || '')} onChange={(e) => setEditData({ ...editData, phone: e.target.value })} disabled={!isEditing} className="h-7 text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="dateOfBirth" className="flex items-center space-x-2">
-                          <Calendar className="w-4 h-4" />
-                          <span>Date of Birth</span>
-                        </Label>
-                        <DobPicker id="dateOfBirth" value={isEditing ? (editData.dateOfBirth || '') : (student?.dateOfBirth || '')} onChange={(v) => setEditData({ ...editData, dateOfBirth: v })} disabled={!isEditing} />
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label htmlFor="address" className="flex items-center space-x-2">
-                          <MapPin className="w-4 h-4" />
-                          <span>Address</span>
-                        </Label>
-                        <Textarea id="address" rows={3} value={isEditing ? (editData.address || '') : (student?.address || '')} onChange={(e) => setEditData({ ...editData, address: e.target.value })} disabled={!isEditing} className="text-[11px] transition-all focus:ring-2 focus:ring-primary/20" />
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-
-                <CollapsibleCard persistKey={`student-details:${authUser?.id || 'anon'}:academic-information`} cardClassName="shadow-sm hover:shadow-md transition-shadow" header={<CardTitle className="flex items-center space-x-2"><GraduationCap className="w-4 h-4 text-primary" /><span>Academic Information</span></CardTitle>}>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="englishProficiency" className="flex items-center space-x-2">
-                        <FileText className="w-4 h-4" />
-                        <span>English Proficiency</span>
-                      </Label>
-                      {isEditing ? (
-                        <Select value={editData.englishProficiency || ''} onValueChange={(v) => setEditData({ ...editData, englishProficiency: v })}>
-                          <SelectTrigger className="h-7 text-[11px]"><SelectValue placeholder="Select proficiency" /></SelectTrigger>
-                          <SelectContent>
-                            {getFieldOptions('englishProficiency').map((opt: any) => (
-                              <SelectItem key={opt.key || opt.id || opt.value} value={(opt.key || opt.id || opt.value) as string}>
-                                {opt.value}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      ) : (
-                        <Input id="englishProficiency" value={getDropdownLabel('englishProficiency', student?.englishProficiency || '')} disabled className="h-7 text-[11px]" />
-                      )}
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label className="flex items-center space-x-2"><span>Counsellor</span></Label>
-                      {isEditing ? (
-                        <Select value={editData.counselorId || ''} onValueChange={(value) => setEditData({ ...editData, counselorId: value })}>
-                          <SelectTrigger className="h-7 text-[11px]"><SelectValue placeholder="Select counsellor" /></SelectTrigger>
-                          <SelectContent>
-                            {counselorOptions().map((opt: any) => (
-                              <SelectItem key={opt.id} value={opt.id}>{opt.value}</SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      ) : (
-                        <div className="text-sm text-gray-700">{(() => { const found = counselorOptions().find((d: any) => d.id === student?.counselorId); return found?.value || 'Unassigned'; })()}</div>
-                      )}
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label className="flex items-center space-x-2"><span>Expectation</span></Label>
-                      {isEditing ? (
-                        <Select value={editData.expectation || ''} onValueChange={(v) => setEditData({ ...editData, expectation: v })}>
-                          <SelectTrigger className="h-7 text-[11px]"><SelectValue placeholder="Select expectation" /></SelectTrigger>
-                          <SelectContent>
-                            {getFieldOptions('expectation').map((opt: any) => (
-                              <SelectItem key={opt.key || opt.id || opt.value} value={(opt.key || opt.id || opt.value) as string}>
-                                {opt.value}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      ) : (
-                        <Input value={getDropdownLabel('expectation', student?.expectation || '')} disabled className="h-7 text-[11px]" />
-                      )}
-                    </div>
-
-                    <div className="space-y-2">
-                      {isEditing ? (
-                        <div className="flex items-center space-x-6">
-                          <div className="flex items-center space-x-3">
-                            <Checkbox checked={!!editData.consultancyFree} onCheckedChange={(v) => setEditData({ ...editData, consultancyFree: !!v })} />
-                            <span className="text-sm">Consultancy Free</span>
-                          </div>
-                          <div className="flex items-center space-x-3">
-                            <Checkbox checked={!!editData.scholarship} onCheckedChange={(v) => setEditData({ ...editData, scholarship: !!v })} />
-                            <span className="text-sm">Scholarship</span>
-                          </div>
+              }
+            >
+              {(!applications || applications.length === 0) ? (
+                <div className="text-xs text-gray-500">No applications yet.</div>
+              ) : (
+                <div className="divide-y">
+                  {applications.map((app) => (
+                    <button
+                      key={app.id}
+                      type="button"
+                      onClick={() => { try { setLocation(`/applications/${app.id}`); } catch {} if (typeof onOpenApplication === 'function') { onOpenApplication(app); onOpenChange(false); } else { setSelectedApplication(app); try { const { useModalManager } = require('@/contexts/ModalManagerContext'); const { openModal } = useModalManager(); openModal(() => setIsAppDetailsOpen(true)); } catch { setIsAppDetailsOpen(true); } onOpenChange(false); } }}
+                      className="w-full text-left flex items-center justify-between py-2 px-2 hover:bg-muted/50 rounded focus:outline-none focus:ring-2 focus:ring-primary/20"
+                    >
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium truncate">{app.university} — {app.program}</div>
+                        <div className="text-xs text-gray-500 truncate">
+                          {(app.country || '-')}{app.intake ? ` • ${app.intake}` : ''}
                         </div>
-                      ) : (
-                        <div className="grid grid-cols-2 gap-3 text-sm">
-                          <div>
-                            <div className="text-[11px] text-gray-600">Consultancy Fee</div>
-                            <div className="text-sm text-gray-700">{student?.consultancyFree ? 'Yes' : 'No'}</div>
-                          </div>
-                          <div>
-                            <div className="text-[11px] text-gray-600">Scholarship</div>
-                            <div className="text-sm text-gray-700">{student?.scholarship ? 'Yes' : 'No'}</div>
-                          </div>
-                        </div>
-                      )}
-                    </div>
+                      </div>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <Badge variant="outline" className="text-[10px]">{app.appStatus}</Badge>
+                        {app.caseStatus && <Badge variant="secondary" className="text-[10px]">{app.caseStatus}</Badge>}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </CollapsibleCard>
 
-                  </div>
-                </CollapsibleCard>
-
-                <CollapsibleCard
-                  persistKey={`student-details:${authUser?.id || 'anon'}:applications`}
-                  cardClassName="shadow-sm hover:shadow-md transition-shadow"
-                  header={
-                    <div className="flex items-center justify-between w-full">
-                      <CardTitle className="flex items-center space-x-2">
-                        <FileText className="w-4 h-4 text-primary" />
-                        <span>Applications</span>
-                        {Array.isArray(applications) && (
-                          <Badge variant="secondary" className="ml-2 text-[10px]">{applications.length}</Badge>
-                        )}
-                      </CardTitle>
-                      <Button variant="outline" size="xs" className="rounded-full px-2 [&_svg]:size-3" onClick={() => { onOpenChange(false); if (typeof onOpenAddApplication === 'function') { setTimeout(() => onOpenAddApplication(student?.id), 160); } }}>
-                        <Plus />
-                        <span>Add Application</span>
-                      </Button>
-                    </div>
-                  }
-                >
-                  {(!applications || applications.length === 0) ? (
-                    <div className="text-xs text-gray-500">No applications yet.</div>
-                  ) : (
-                    <div className="divide-y">
-                      {applications.map((app) => (
-                        <button
-                          key={app.id}
-                          type="button"
-                          onClick={() => { try { setLocation(`/applications/${app.id}`); } catch {} if (typeof onOpenApplication === 'function') { onOpenApplication(app); onOpenChange(false); } else { setSelectedApplication(app); try { const { useModalManager } = require('@/contexts/ModalManagerContext'); const { openModal } = useModalManager(); openModal(() => setIsAppDetailsOpen(true)); } catch { setIsAppDetailsOpen(true); } onOpenChange(false); } }}
-                          className="w-full text-left flex items-center justify-between py-2 px-2 hover:bg-muted/50 rounded focus:outline-none focus:ring-2 focus:ring-primary/20"
-                        >
-                          <div className="min-w-0">
-                            <div className="text-sm font-medium truncate">{app.university} — {app.program}</div>
-                            <div className="text-xs text-gray-500 truncate">
-                              {(app.country || '-')}{app.intake ? ` • ${app.intake}` : ''}
-                            </div>
-                          </div>
-                          <div className="flex items-center gap-2 shrink-0">
-                            <Badge variant="outline" className="text-[10px]">{app.appStatus}</Badge>
-                            {app.caseStatus && <Badge variant="secondary" className="text-[10px]">{app.caseStatus}</Badge>}
-                          </div>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </CollapsibleCard>
-
-              </div>
-            </div>
-
-            {/* Right: Timeline */}
-            <div className="bg-white flex flex-col min-h-0">
-              <div className="flex-1 overflow-y-auto pt-1 min-h-0">
-                <ActivityTracker entityType="student" entityId={student.id} entityName={student.name} />
-              </div>
-            </div>
+          </>
+        )}
+        rightContent={(
+          <div className="pt-1">
+            <ActivityTracker entityType="student" entityId={student.id} entityName={student.name} />
           </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+        )}
+        rightWidthClassName="w-[420px]"
+      />
 
 
       <ApplicationDetailsModal

--- a/frontend/src/components/student-profile-modal-new.tsx
+++ b/frontend/src/components/student-profile-modal-new.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { DetailsDialogLayout } from '@/components/ui/details-dialog';
 console.log('[modal] loaded: frontend/src/components/student-profile-modal-new.tsx');
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/components/ui/details-dialog.tsx
+++ b/frontend/src/components/ui/details-dialog.tsx
@@ -1,0 +1,82 @@
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { X } from 'lucide-react';
+import React from 'react';
+
+interface DetailsDialogLayoutProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  headerLeft?: React.ReactNode;
+  headerRight?: React.ReactNode;
+  statusBar?: React.ReactNode;
+  leftContent: React.ReactNode;
+  rightContent?: React.ReactNode;
+  rightWidthClassName?: string; // e.g. w-[420px]
+  contentClassName?: string;
+  headerClassName?: string; // e.g. 'bg-primary text-primary-foreground'
+  showDefaultClose?: boolean;
+}
+
+export const DetailsDialogLayout: React.FC<DetailsDialogLayoutProps> = ({
+  open,
+  onOpenChange,
+  title,
+  headerLeft,
+  headerRight,
+  statusBar,
+  leftContent,
+  rightContent,
+  rightWidthClassName = 'w-[420px]',
+  contentClassName = 'no-not-allowed max-w-6xl w-[95vw] max-h-[90vh] overflow-hidden p-0 rounded-xl shadow-xl',
+  headerClassName = 'bg-white',
+  showDefaultClose,
+}) => {
+  const hasRight = !!rightContent;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent hideClose className={contentClassName}>
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <div className="flex flex-col h-[90vh] min-h-0 bg-white">
+          {/* Header */}
+          <div className="sticky top-0 z-20">
+            <div className={`px-4 py-3 flex items-center justify-between ${headerClassName}`}>
+              <div className="min-w-0 flex-1">{headerLeft}</div>
+              <div className="flex items-center gap-2">
+                {headerRight}
+                {showDefaultClose && (
+                  <button
+                    type="button"
+                    aria-label="Close"
+                    onClick={() => onOpenChange(false)}
+                    className="rounded-full w-8 h-8 inline-flex items-center justify-center bg-white/80 text-gray-700 hover:bg-white"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+            {statusBar && (
+              <div className="px-4 py-2 bg-gray-50 border-t">{statusBar}</div>
+            )}
+          </div>
+
+          {/* Body */}
+          <div className={hasRight ? `grid grid-cols-[1fr_${rightWidthClassName}] flex-1 min-h-0` : 'flex-1 min-h-0'}>
+            <div className="flex flex-col min-h-0">
+              <div className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
+                {leftContent}
+              </div>
+            </div>
+            {hasRight && (
+              <div className="border-l bg-white flex flex-col min-h-0">
+                <div className="flex-1 overflow-y-auto min-h-0">
+                  {rightContent}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/ui/details-dialog.tsx
+++ b/frontend/src/components/ui/details-dialog.tsx
@@ -12,7 +12,8 @@ interface DetailsDialogLayoutProps {
   statusBarWrapperClassName?: string;
   leftContent: React.ReactNode;
   rightContent?: React.ReactNode;
-  rightWidthClassName?: string; // e.g. w-[420px]
+  rightWidth?: string; // e.g. '420px'
+  rightWidthClassName?: string; // legacy support e.g. 'w-[420px]'
   contentClassName?: string;
   headerClassName?: string; // e.g. 'bg-primary text-primary-foreground'
   showDefaultClose?: boolean;
@@ -28,12 +29,17 @@ export const DetailsDialogLayout: React.FC<DetailsDialogLayoutProps> = ({
   statusBarWrapperClassName = 'px-4 py-2 bg-gray-50 border-t',
   leftContent,
   rightContent,
+  rightWidth,
   rightWidthClassName = 'w-[420px]',
   contentClassName = 'no-not-allowed max-w-6xl w-[95vw] max-h-[90vh] overflow-hidden p-0 rounded-xl shadow-xl',
   headerClassName = 'bg-white',
   showDefaultClose,
 }) => {
   const hasRight = !!rightContent;
+  // Determine right pane width (support old prop form like 'w-[420px]')
+  const extracted = rightWidthClassName?.match(/\[(.+?)\]/)?.[1];
+  const rightPaneWidth = rightWidth || extracted || '420px';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent hideClose className={contentClassName}>
@@ -63,14 +69,14 @@ export const DetailsDialogLayout: React.FC<DetailsDialogLayoutProps> = ({
           </div>
 
           {/* Body */}
-          <div className={hasRight ? `grid grid-cols-[1fr_${rightWidthClassName}] flex-1 min-h-0` : 'flex-1 min-h-0'}>
+          <div className={hasRight ? 'grid flex-1 min-h-0' : 'flex-1 min-h-0'} style={hasRight ? { gridTemplateColumns: `1fr ${rightPaneWidth}` } : undefined}>
             <div className="flex flex-col min-h-0">
               <div className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
                 {leftContent}
               </div>
             </div>
             {hasRight && (
-              <div className="border-l bg-white flex flex-col min-h-0">
+              <div className="border-l bg-white flex flex-col min-h-0" style={{ width: rightPaneWidth }}>
                 <div className="flex-1 overflow-y-auto min-h-0">
                   {rightContent}
                 </div>

--- a/frontend/src/components/ui/details-dialog.tsx
+++ b/frontend/src/components/ui/details-dialog.tsx
@@ -9,6 +9,7 @@ interface DetailsDialogLayoutProps {
   headerLeft?: React.ReactNode;
   headerRight?: React.ReactNode;
   statusBar?: React.ReactNode;
+  statusBarWrapperClassName?: string;
   leftContent: React.ReactNode;
   rightContent?: React.ReactNode;
   rightWidthClassName?: string; // e.g. w-[420px]
@@ -24,6 +25,7 @@ export const DetailsDialogLayout: React.FC<DetailsDialogLayoutProps> = ({
   headerLeft,
   headerRight,
   statusBar,
+  statusBarWrapperClassName = 'px-4 py-2 bg-gray-50 border-t',
   leftContent,
   rightContent,
   rightWidthClassName = 'w-[420px]',
@@ -56,7 +58,7 @@ export const DetailsDialogLayout: React.FC<DetailsDialogLayoutProps> = ({
               </div>
             </div>
             {statusBar && (
-              <div className="px-4 py-2 bg-gray-50 border-t">{statusBar}</div>
+              <div className={statusBarWrapperClassName}>{statusBar}</div>
             )}
           </div>
 

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -64,7 +64,7 @@ export default function Login({ onLogin }: LoginProps) {
   return (
     <main role="main" className="min-h-screen bg-white flex">
       {/* Left Side - Branding */}
-      <aside aria-label="Branding" className="hidden lg:flex lg:w-1/2 bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-800 p-12 flex-col justify-between relative overflow-hidden">
+      <aside aria-label="Branding" className="hidden lg:flex lg:w-1/2 bg-[#223E7D] p-12 flex-col justify-between relative overflow-hidden">
         {/* Background Pattern (decorative) */}
         <div className="absolute inset-0 opacity-10" aria-hidden="true">
           <div className="absolute top-20 left-20 w-32 h-32 bg-white rounded-full"></div>
@@ -77,9 +77,9 @@ export default function Login({ onLogin }: LoginProps) {
         <header className="relative z-10">
           <div className="flex items-center space-x-3 mb-8">
             <div className="w-12 h-12 bg-white rounded-xl flex items-center justify-center" aria-hidden="true">
-              <GraduationCap className="w-7 h-7 text-blue-600" aria-hidden="true" />
+              <GraduationCap className="w-7 h-7 text-[#223E7D]" aria-hidden="true" />
             </div>
-            <h1 className="text-3xl font-bold text-white">SetCrm</h1>
+            <h1 className="text-3xl font-bold text-white">SetCRM</h1>
           </div>
 
           <div className="space-y-6">
@@ -144,10 +144,10 @@ export default function Login({ onLogin }: LoginProps) {
           {/* Mobile Logo */}
           <div className="lg:hidden flex items-center justify-center mb-8">
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 bg-blue-600 rounded-xl flex items-center justify-center" aria-hidden="true">
+              <div className="w-10 h-10 bg-[#223E7D] rounded-xl flex items-center justify-center" aria-hidden="true">
                 <GraduationCap className="w-6 h-6 text-white" aria-hidden="true" />
               </div>
-              <h1 className="text-2xl font-bold text-gray-900">SetCrm</h1>
+              <h1 className="text-2xl font-bold text-gray-900">SetCRM</h1>
             </div>
           </div>
 
@@ -173,7 +173,7 @@ export default function Login({ onLogin }: LoginProps) {
                           placeholder="Enter your email"
                           autoComplete="email"
                           inputMode="email"
-                          className="h-12 border-gray-300 focus:border-blue-500 focus:ring-blue-500 bg-white"
+                          className="h-12 border-gray-300 focus:border-[#223E7D] focus:ring-[#223E7D] bg-white"
                         />
                       </FormControl>
                       <FormMessage />
@@ -209,7 +209,7 @@ export default function Login({ onLogin }: LoginProps) {
                           type={showPassword ? "text" : "password"}
                           placeholder="Enter your password"
                           autoComplete="current-password"
-                          className="h-12 border-gray-300 focus:border-blue-500 focus:ring-blue-500 bg-white"
+                          className="h-12 border-gray-300 focus:border-[#223E7D] focus:ring-[#223E7D] bg-white"
                         />
                       </FormControl>
                       <FormMessage />
@@ -223,7 +223,7 @@ export default function Login({ onLogin }: LoginProps) {
                       id="remember-me"
                       name="remember-me"
                       type="checkbox"
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                      className="h-4 w-4 text-[#223E7D] focus:ring-[#223E7D] border-gray-300 rounded"
                     />
                     <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-700">
                       Remember me
@@ -231,7 +231,7 @@ export default function Login({ onLogin }: LoginProps) {
                   </div>
                   <button
                     type="button"
-                    className="text-sm text-blue-600 hover:text-blue-500 font-medium"
+                    className="text-sm text-[#223E7D] hover:opacity-90 font-medium"
                     aria-label="Forgot password"
                   >
                     Forgot password?
@@ -247,7 +247,7 @@ export default function Login({ onLogin }: LoginProps) {
 
                 <Button
                   type="submit"
-                  className="w-full h-12 bg-blue-600 hover:bg-blue-700 text-white font-semibold transition-colors duration-200 disabled:opacity-50"
+                  className="w-full h-12 bg-[#223E7D] hover:bg-[#223E7D]/90 text-white font-semibold transition-colors duration-200 disabled:opacity-50"
                   disabled={isLoading}
                   aria-busy={isLoading}
                 >
@@ -266,7 +266,7 @@ export default function Login({ onLogin }: LoginProps) {
             <div className="text-center">
               <p className="text-sm text-gray-500">
                 Don't have an account?{' '}
-                <button className="text-blue-600 hover:text-blue-500 font-medium" aria-label="Contact Administrator">
+                <button className="text-[#223E7D] hover:opacity-90 font-medium" aria-label="Contact Administrator">
                   Contact Administrator
                 </button>
               </p>


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses several UI improvements:
- Update login page colors to use the specified brand color (#223E7D)
- Fix branding consistency by changing "SetCrm" to "SetCRM" 
- Create a reusable dialog component for student details to enable consistent design across modules
- Maintain the existing layout structure (information on left, activity on right)

## Code changes
- **Login page styling**: Applied #223E7D color to left panel, login button, contact admin link, and forgot password link
- **Brand consistency**: Updated "SetCrm" to "SetCRM" in both sidebar and login page
- **Component refactoring**: 
  - Created new `DetailsDialogLayout` component in `ui/details-dialog.tsx` as a reusable dialog layout
  - Refactored `StudentDetailsModal` to use the new reusable component
  - Maintained original layout with information content on left and activity tracker on right
- **Improved modularity**: The new dialog component can be easily reused in other modules with consistent design patternsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 71`

🔗 [Edit in Builder.io](https://builder.io/app/projects/128e3edf1e8c4bf1bbd4c0e6106fe983/pixel-space)

👀 [Preview Link](https://128e3edf1e8c4bf1bbd4c0e6106fe983-pixel-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>128e3edf1e8c4bf1bbd4c0e6106fe983</projectId>-->
<!--<branchName>pixel-space</branchName>-->