### PR TITLE
Fix admission officer display and add status defaults

### DIFF
--- a/frontend/src/components/add-lead-form.tsx
+++ b/frontend/src/components/add-lead-form.tsx
@@ -460,6 +460,20 @@ export default function AddLeadForm({ onCancel, onSuccess, showBackButton = fals
         if (defaultStatus && !form.getValues('status')) {
           form.setValue('status', defaultStatus.key || defaultStatus.id || defaultStatus.value);
         }
+        // Fallback: if no default is set in dropdowns, prefer 'Raw' as the initial priority
+        if (!form.getValues('status')) {
+          const rawOption = statusList.find((s: any) => {
+            const val = String(s.value || '').toLowerCase();
+            const key = String(s.key || s.id || '').toLowerCase();
+            return val === 'raw' || key === 'raw' || val.includes('raw');
+          });
+          if (rawOption) {
+            form.setValue('status', rawOption.key || rawOption.id || rawOption.value);
+          } else {
+            // As a last resort, set literal 'Raw' so validation passes and backend stores a sensible default
+            form.setValue('status', 'Raw');
+          }
+        }
       } catch {}
 
       try {

--- a/frontend/src/components/add-lead-form.tsx
+++ b/frontend/src/components/add-lead-form.tsx
@@ -866,12 +866,12 @@ export default function AddLeadForm({ onCancel, onSuccess, showBackButton = fals
                     <FormItem>
                       <FormLabel className="flex items-center space-x-2">
                         <Target className="w-4 h-4" />
-                        <span>Priority Level</span>
+                        <span>Status</span>
                       </FormLabel>
                       <Select onValueChange={field.onChange} value={field.value}>
                         <FormControl>
                           <SelectTrigger className="transition-all focus:ring-2 focus:ring-primary/20">
-                            <SelectValue placeholder="Set priority" />
+                            <SelectValue placeholder="Select status" />
                           </SelectTrigger>
                         </FormControl>
                         <SelectContent>

--- a/frontend/src/components/add-lead-modal.tsx
+++ b/frontend/src/components/add-lead-modal.tsx
@@ -498,12 +498,12 @@ export function AddLeadModal({ open, onOpenChange, initialData }: AddLeadModalPr
                       <FormItem>
                         <FormLabel className="flex items-center space-x-2">
                           <Target className="w-4 h-4" />
-                          <span>Priority Level</span>
+                          <span>Status</span>
                         </FormLabel>
                         <Select onValueChange={field.onChange} value={field.value}>
                           <FormControl>
                             <SelectTrigger className="transition-all focus:ring-2 focus:ring-primary/20">
-                              <SelectValue placeholder="Set priority" />
+                              <SelectValue placeholder="Select status" />
                             </SelectTrigger>
                           </FormControl>
                           <SelectContent>

--- a/frontend/src/components/convert-to-student-modal.tsx
+++ b/frontend/src/components/convert-to-student-modal.tsx
@@ -261,11 +261,20 @@ export function ConvertToStudentModal({ open, onOpenChange, lead, onSuccess }: C
       const def = list.find((o: any) => o?.is_default === 1 || o?.isDefault === 1 || o?.is_default === '1' || o?.isDefault === '1');
       return def ? (def.key ?? def.id ?? def.value ?? '') : '';
     };
+    const findByLabel = (candidates: string[], label: string) => {
+      const list = findList(candidates);
+      const lname = label.toLowerCase();
+      const item = list.find((o: any) => String(o.value || '').toLowerCase() === lname || String(o.key || o.id || '').toLowerCase() === lname);
+      return item ? (item.key ?? item.id ?? item.value ?? '') : '';
+    };
+
+    const openKey = findByLabel(['Status', 'status'], 'open');
+    const averageKey = findByLabel(['Expectation', 'expectation'], 'average');
 
     setFormData(prev => ({
       ...prev,
-      status: prev.status || pickDefaultFrom(['Status', 'status']),
-      expectation: prev.expectation || pickDefaultFrom(['Expectation', 'expectation']),
+      status: prev.status || openKey || pickDefaultFrom(['Status', 'status']),
+      expectation: prev.expectation || averageKey || pickDefaultFrom(['Expectation', 'expectation']),
       eltTest: prev.eltTest || pickDefaultFrom(['ELT Test', 'ELTTest', 'ELT_Test']),
     }));
   }, [studentDropdowns]);

--- a/frontend/src/components/lead-details-modal.tsx
+++ b/frontend/src/components/lead-details-modal.tsx
@@ -498,10 +498,9 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
                   <Label className="flex items-center space-x-2"><Users className="w-4 h-4" /><span>Admission Officer</span></Label>
                   <div className="text-xs px-2 py-1.5 rounded border bg-white">
                     {(() => {
-                      const norm = (v: string) => String(v || '').toLowerCase().replace(/\s+/g,'_').replace(/-+/g,'_');
-                      const branchId = (lead as any).branchId || (editData as any).branchId;
-                      const officer = Array.isArray(users)
-                        ? users.find((u: any) => (String(u.branchId || '') === String(branchId)) && norm(u.role) === 'admission_officer')
+                      const officerId = (lead as any).admissionOfficerId || (lead as any).admission_officer_id || (editData as any)?.admissionOfficerId || (editData as any)?.admission_officer_id || '';
+                      const officer = officerId && Array.isArray(users)
+                        ? (users as any[]).find((u: any) => String(u.id) === String(officerId))
                         : null;
                       if (!officer) return '—';
                       const fullName = [officer.firstName || officer.first_name, officer.lastName || officer.last_name].filter(Boolean).join(' ').trim();

--- a/frontend/src/components/student-profile-modal-new.tsx
+++ b/frontend/src/components/student-profile-modal-new.tsx
@@ -42,7 +42,8 @@ import {
   BookOpen,
   Target,
   Users,
-  User as UserIcon
+  User as UserIcon,
+  Globe
 } from 'lucide-react';
 
 interface StudentProfileModalProps {
@@ -104,6 +105,12 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAppli
     queryFn: async () => DropdownsService.getModuleDropdowns('students'),
     enabled: open,
   });
+  // Fallback to Leads module for target country options if needed
+  const { data: leadsDropdowns } = useQuery({
+    queryKey: ['/api/dropdowns/module/Leads'],
+    queryFn: async () => DropdownsService.getModuleDropdowns('Leads'),
+    enabled: open,
+  });
 
   const { data: users = [] } = useQuery<User[]>({
     queryKey: ['/api/users'],
@@ -129,14 +136,23 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAppli
   const normalize = (s: string) => (s || '').toString().toLowerCase().replace(/[^a-z0-9]/g, '');
   const getFieldOptions = (fieldName: string): any[] => {
     const data = dropdownData as any;
-    if (!data) return [];
+    const leadsData = leadsDropdowns as any;
     const target = normalize(fieldName);
     const candidates = [target];
     if (target === 'englishproficiency') {
       candidates.push('elttest', 'elt', 'englishtest', 'english');
     }
-    const entry = Object.entries(data).find(([k]) => candidates.includes(normalize(String(k))));
-    return (entry?.[1] as any[]) || [];
+    if (target === 'targetcountry') {
+      candidates.push('targetcountry', 'interestedcountry', 'country');
+    }
+    const findIn = (obj: any) => {
+      if (!obj || typeof obj !== 'object') return [] as any[];
+      const entry = Object.entries(obj).find(([k]) => candidates.includes(normalize(String(k))));
+      return (entry?.[1] as any[]) || [];
+    };
+    const opts = findIn(data);
+    if (opts.length > 0) return opts;
+    return findIn(leadsData);
   };
   const getDropdownLabel = (fieldName: string, value?: string | null) => {
     if (!value) return '';
@@ -160,6 +176,7 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAppli
         // Normalize dropdown-backed fields to option keys for proper Select pre-selection
         expectation: mapToOptionValue('expectation', student.expectation),
         englishProficiency: mapToOptionValue('englishProficiency', (student as any).englishProficiency),
+        targetCountry: mapToOptionValue('targetCountry', (student as any).targetCountry),
       });
       setCurrentStatus(student.status);
     }
@@ -608,6 +625,24 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAppli
                     </Select>
                   ) : (
                     <Input value={getDropdownLabel('expectation', student?.expectation || '')} disabled className="h-7 text-[11px]" />
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label className="flex items-center space-x-2"><Globe className="w-4 h-4" /><span>Target Country</span></Label>
+                  {isEditing ? (
+                    <Select value={(editData as any).targetCountry || ''} onValueChange={(v) => setEditData({ ...editData, targetCountry: v })}>
+                      <SelectTrigger className="h-7 text-[11px]"><SelectValue placeholder="Select country" /></SelectTrigger>
+                      <SelectContent>
+                        {getFieldOptions('targetCountry').map((opt: any) => (
+                          <SelectItem key={opt.key || opt.id || opt.value} value={(opt.key || opt.id || opt.value) as string}>
+                            {opt.value}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <Input value={getDropdownLabel('targetCountry', (student as any)?.targetCountry || '')} disabled className="h-7 text-[11px]" />
                   )}
                 </div>
 

--- a/frontend/src/components/student-profile-modal-new.tsx
+++ b/frontend/src/components/student-profile-modal-new.tsx
@@ -531,10 +531,9 @@ export function StudentProfileModal({ open, onOpenChange, studentId, onOpenAppli
                   <Label className="flex items-center space-x-2"><UserIcon className="w-4 h-4" /><span>Admission Officer</span></Label>
                   <div className="text-xs px-2 py-1.5 rounded border bg-white">
                     {(() => {
-                      const norm = (v: string) => String(v || '').toLowerCase().replace(/\s+/g,'_').replace(/-+/g,'_');
-                      const branchId = (student as any).branchId || (editData as any).branchId;
-                      const officer = Array.isArray(users)
-                        ? (users as any[]).find((u: any) => (String(u.branchId || '') === String(branchId)) && norm(u.role || u.roleId || '') === 'admission_officer')
+                      const officerId = (student as any).admissionOfficerId || (student as any).admission_officer_id || (editData as any)?.admissionOfficerId || (editData as any)?.admission_officer_id || '';
+                      const officer = officerId && Array.isArray(users)
+                        ? (users as any[]).find((u: any) => String(u.id) === String(officerId))
                         : null;
                       if (!officer) return '—';
                       const fullName = [officer.firstName || officer.first_name, officer.lastName || officer.last_name].filter(Boolean).join(' ').trim();

--- a/frontend/src/pages/convert-to-student.tsx
+++ b/frontend/src/pages/convert-to-student.tsx
@@ -201,11 +201,20 @@ export default function ConvertLeadToStudent() {
       const def = list.find((o: any) => o?.is_default === 1 || o?.isDefault === 1 || o?.is_default === '1' || o?.isDefault === '1');
       return def ? (def.key ?? def.id ?? def.value ?? '') : '';
     };
+    const findByLabel = (candidates: string[], label: string) => {
+      const list = findList(candidates);
+      const lname = label.toLowerCase();
+      const item = list.find((o: any) => String(o.value || '').toLowerCase() === lname || String(o.key || o.id || '').toLowerCase() === lname);
+      return item ? (item.key ?? item.id ?? item.value ?? '') : '';
+    };
+
+    const openKey = findByLabel(['Status', 'status'], 'open');
+    const averageKey = findByLabel(['Expectation', 'expectation'], 'average');
 
     setFormData(prev => ({
       ...prev,
-      status: prev.status || pickDefaultFrom(['Status', 'status']),
-      expectation: prev.expectation || pickDefaultFrom(['Expectation', 'expectation']),
+      status: prev.status || openKey || pickDefaultFrom(['Status', 'status']),
+      expectation: prev.expectation || averageKey || pickDefaultFrom(['Expectation', 'expectation']),
       eltTest: prev.eltTest || pickDefaultFrom(['ELT Test', 'ELTTest', 'ELT_Test']),
     }));
   }, [studentDropdowns]);

--- a/frontend/src/pages/leads.tsx
+++ b/frontend/src/pages/leads.tsx
@@ -134,7 +134,7 @@ export default function Leads() {
   const { data: leadById } = useQuery({
     queryKey: ['/api/leads', leadParams?.id],
     queryFn: async () => LeadsService.getLead(leadParams?.id),
-    enabled: Boolean(matchLead && leadParams?.id),
+    enabled: Boolean(matchLead && leadParams?.id && leadParams.id !== 'new'),
     staleTime: 0,
   });
 


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several issues with lead and student management:
- Fix admission officer display showing incorrect/random emails instead of proper officer information
- Add target country field to student academic information section
- Pre-select "Open" status and "Average" expectation when converting leads to students
- Improve status field labeling and default selection in lead forms

## Code changes

**Admission Officer Display Fix:**
- Updated lead and student profile modals to use `admissionOfficerId` field instead of branch-based role matching
- Changed logic to find officers by ID rather than branch + role combination

**Status and Expectation Defaults:**
- Added logic to pre-select "Open" status and "Average" expectation in convert-to-student flows
- Implemented fallback to "Raw" status in add-lead forms when no default is available
- Updated field labels from "Priority Level" to "Status" for clarity

**Target Country Field:**
- Added target country field to student academic information section
- Integrated dropdown options from both Students and Leads modules
- Added Globe icon and proper form controls for editing

**Query Optimization:**
- Fixed lead query to avoid unnecessary API calls when creating new leadsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 98`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c02edd2aa7d44166b19454dcf2612c23/vibe-home)

👀 [Preview Link](https://c02edd2aa7d44166b19454dcf2612c23-vibe-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c02edd2aa7d44166b19454dcf2612c23</projectId>-->
<!--<branchName>vibe-home</branchName>-->