### PR TITLE
Fix intake_id population from university_intakes table

### DIFF
--- a/backend/src/models/University.ts
+++ b/backend/src/models/University.ts
@@ -29,7 +29,7 @@ export class UniversityModel {
     if (!uni) return null;
 
     const intakes = await db
-      .select({ intakeLabel: universityIntakes.intakeLabel })
+      .select({ id: universityIntakes.id, intakeLabel: universityIntakes.intakeLabel })
       .from(universityIntakes)
       .where(eq(universityIntakes.universityId, id));
 
@@ -74,6 +74,7 @@ export class UniversityModel {
         studyGap: uni.studyGap,
         priority: uni.priority,
         intakes: intakes.map(i => i.intakeLabel),
+        intakesWithIds: intakes.map(i => ({ id: i.id, intakeLabel: i.intakeLabel })),
         acceptedElts: acceptedElts.map(e => e.eltName),
       },
       resources: {

--- a/frontend/src/components/add-application-modal.tsx
+++ b/frontend/src/components/add-application-modal.tsx
@@ -449,8 +449,10 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                               setSelectedUniversityId(null);
                               form.setValue('university', '');
                               form.setValue('program', '');
+                              form.setValue('courseId', '');
                               form.setValue('courseType', '');
                               form.setValue('intake', '');
+                              form.setValue('intakeId', '');
                             }}
                             value={field.value || ''}
                           >
@@ -489,7 +491,9 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                               // reset program/course/intake
                               form.setValue('courseType', '');
                               form.setValue('program', '');
+                              form.setValue('courseId', '');
                               form.setValue('intake', '');
+                              form.setValue('intakeId', '');
                             }}
                           >
                             <FormControl>
@@ -522,6 +526,7 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                             onValueChange={(val) => {
                               field.onChange(val);
                               form.setValue('program', '');
+                              form.setValue('courseId', '');
                             }}
                             value={field.value || ''}
                           >
@@ -552,7 +557,19 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                         <FormControl>
                           <Select
                             disabled={!selectedUniversityId || !selectedCourseType}
-                            onValueChange={field.onChange}
+                            onValueChange={(val) => {
+                              field.onChange(val);
+                              try {
+                                const course = filteredCourses.find((c: any) => String(c.name) === String(val));
+                                if (course && course.id) {
+                                  form.setValue('courseId', String(course.id));
+                                } else {
+                                  form.setValue('courseId', '');
+                                }
+                              } catch {
+                                form.setValue('courseId', '');
+                              }
+                            }}
                             value={field.value || ''}
                           >
                             <FormControl>
@@ -588,7 +605,20 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                         <FormControl>
                           <Select
                             disabled={!selectedUniversityId}
-                            onValueChange={field.onChange}
+                            onValueChange={(val) => {
+                              field.onChange(val);
+                              try {
+                                const withIds = ((uniDetail?.admissionRequirements as any)?.intakesWithIds || []) as any[];
+                                const match = Array.isArray(withIds) ? withIds.find((i) => String(i.intakeLabel) === String(val)) : null;
+                                if (match && match.id) {
+                                  form.setValue('intakeId', String(match.id));
+                                } else {
+                                  form.setValue('intakeId', '');
+                                }
+                              } catch {
+                                form.setValue('intakeId', '');
+                              }
+                            }}
                             value={field.value || ''}
                           >
                             <FormControl>
@@ -597,9 +627,13 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                               </SelectTrigger>
                             </FormControl>
                             <SelectContent>
-                              {((uniDetail?.admissionRequirements?.intakes || []) as string[]).map((i) => (
-                                <SelectItem key={i} value={i}>{i}</SelectItem>
-                              ))}
+                              {(((uniDetail?.admissionRequirements as any)?.intakesWithIds as any[]) || [])?.length
+                                ? (((uniDetail?.admissionRequirements as any)?.intakesWithIds as any[]) || []).map((i: any) => (
+                                    <SelectItem key={i.id} value={i.intakeLabel}>{i.intakeLabel}</SelectItem>
+                                  ))
+                                : ((uniDetail?.admissionRequirements?.intakes || []) as string[]).map((i) => (
+                                    <SelectItem key={i} value={i}>{i}</SelectItem>
+                                  ))}
                             </SelectContent>
                           </Select>
                         </FormControl>

--- a/frontend/src/components/add-application-modal.tsx
+++ b/frontend/src/components/add-application-modal.tsx
@@ -116,7 +116,6 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
   const appStatusOptions = makeOptions(applicationsDropdowns, ['Application Status','App Status','Status','AppStatus','status']);
   const caseStatusOptions = makeOptions(applicationsDropdowns, ['Case Status','caseStatus','CaseStatus','case_status']);
   const channelPartnerOptions = makeOptions(applicationsDropdowns, ['Channel Partner', 'ChannelPartners', 'channelPartner', 'channel_partners']);
-  const intakeOptions = makeOptions(applicationsDropdowns, ['Intake','intake','Intakes']);
 
   const form = useForm({
     resolver: zodResolver(insertApplicationSchema),
@@ -605,27 +604,17 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                         <FormLabel>Intake</FormLabel>
                         <FormControl>
                           <Select
-                            disabled={!selectedUniversityId && intakeOptions.length === 0}
+                            disabled={!selectedUniversityId}
                             onValueChange={(val) => {
                               field.onChange(val);
                               try {
                                 const withIds = ((uniDetail?.admissionRequirements as any)?.intakesWithIds || []) as any[];
-                                let set = false;
-                                if (Array.isArray(withIds) && withIds.length) {
-                                  const match = withIds.find((i) => String(i.intakeLabel) === String(val));
-                                  if (match && match.id) {
-                                    form.setValue('intakeId', String(match.id));
-                                    set = true;
-                                  }
+                                const match = Array.isArray(withIds) ? withIds.find((i) => String(i.intakeLabel) === String(val)) : null;
+                                if (match && match.id) {
+                                  form.setValue('intakeId', String(match.id));
+                                } else {
+                                  form.setValue('intakeId', '');
                                 }
-                                if (!set && Array.isArray(intakeOptions) && intakeOptions.length) {
-                                  const opt = intakeOptions.find((o) => String(o.label) === String(val));
-                                  if (opt && opt.value) {
-                                    form.setValue('intakeId', String(opt.value));
-                                    set = true;
-                                  }
-                                }
-                                if (!set) form.setValue('intakeId', '');
                               } catch {
                                 form.setValue('intakeId', '');
                               }
@@ -633,8 +622,8 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                             value={field.value || ''}
                           >
                             <FormControl>
-                              <SelectTrigger disabled={!selectedUniversityId && intakeOptions.length === 0}>
-                                <SelectValue placeholder={(selectedUniversityId || intakeOptions.length) ? 'Select intake' : 'Select university first'} />
+                              <SelectTrigger disabled={!selectedUniversityId}>
+                                <SelectValue placeholder={selectedUniversityId ? 'Select intake' : 'Select university first'} />
                               </SelectTrigger>
                             </FormControl>
                             <SelectContent>
@@ -642,14 +631,9 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                                 ? (((uniDetail?.admissionRequirements as any)?.intakesWithIds as any[]) || []).map((i: any) => (
                                     <SelectItem key={i.id} value={i.intakeLabel}>{i.intakeLabel}</SelectItem>
                                   ))
-                                : (intakeOptions.length
-                                  ? intakeOptions.map((opt) => (
-                                      <SelectItem key={String(opt.value)} value={opt.label}>{opt.label}</SelectItem>
-                                    ))
-                                  : ((uniDetail?.admissionRequirements?.intakes || []) as string[]).map((i) => (
-                                      <SelectItem key={i} value={i}>{i}</SelectItem>
-                                    ))
-                                  )}
+                                : ((uniDetail?.admissionRequirements?.intakes || []) as string[]).map((i) => (
+                                    <SelectItem key={i} value={i}>{i}</SelectItem>
+                                  ))}
                             </SelectContent>
                           </Select>
                         </FormControl>

--- a/frontend/src/components/add-application-modal.tsx
+++ b/frontend/src/components/add-application-modal.tsx
@@ -116,6 +116,7 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
   const appStatusOptions = makeOptions(applicationsDropdowns, ['Application Status','App Status','Status','AppStatus','status']);
   const caseStatusOptions = makeOptions(applicationsDropdowns, ['Case Status','caseStatus','CaseStatus','case_status']);
   const channelPartnerOptions = makeOptions(applicationsDropdowns, ['Channel Partner', 'ChannelPartners', 'channelPartner', 'channel_partners']);
+  const intakeOptions = makeOptions(applicationsDropdowns, ['Intake','intake','Intakes']);
 
   const form = useForm({
     resolver: zodResolver(insertApplicationSchema),
@@ -604,17 +605,27 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                         <FormLabel>Intake</FormLabel>
                         <FormControl>
                           <Select
-                            disabled={!selectedUniversityId}
+                            disabled={!selectedUniversityId && intakeOptions.length === 0}
                             onValueChange={(val) => {
                               field.onChange(val);
                               try {
                                 const withIds = ((uniDetail?.admissionRequirements as any)?.intakesWithIds || []) as any[];
-                                const match = Array.isArray(withIds) ? withIds.find((i) => String(i.intakeLabel) === String(val)) : null;
-                                if (match && match.id) {
-                                  form.setValue('intakeId', String(match.id));
-                                } else {
-                                  form.setValue('intakeId', '');
+                                let set = false;
+                                if (Array.isArray(withIds) && withIds.length) {
+                                  const match = withIds.find((i) => String(i.intakeLabel) === String(val));
+                                  if (match && match.id) {
+                                    form.setValue('intakeId', String(match.id));
+                                    set = true;
+                                  }
                                 }
+                                if (!set && Array.isArray(intakeOptions) && intakeOptions.length) {
+                                  const opt = intakeOptions.find((o) => String(o.label) === String(val));
+                                  if (opt && opt.value) {
+                                    form.setValue('intakeId', String(opt.value));
+                                    set = true;
+                                  }
+                                }
+                                if (!set) form.setValue('intakeId', '');
                               } catch {
                                 form.setValue('intakeId', '');
                               }
@@ -622,8 +633,8 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                             value={field.value || ''}
                           >
                             <FormControl>
-                              <SelectTrigger disabled={!selectedUniversityId}>
-                                <SelectValue placeholder={selectedUniversityId ? 'Select intake' : 'Select university first'} />
+                              <SelectTrigger disabled={!selectedUniversityId && intakeOptions.length === 0}>
+                                <SelectValue placeholder={(selectedUniversityId || intakeOptions.length) ? 'Select intake' : 'Select university first'} />
                               </SelectTrigger>
                             </FormControl>
                             <SelectContent>
@@ -631,9 +642,14 @@ export function AddApplicationModal({ open, onOpenChange, studentId }: AddApplic
                                 ? (((uniDetail?.admissionRequirements as any)?.intakesWithIds as any[]) || []).map((i: any) => (
                                     <SelectItem key={i.id} value={i.intakeLabel}>{i.intakeLabel}</SelectItem>
                                   ))
-                                : ((uniDetail?.admissionRequirements?.intakes || []) as string[]).map((i) => (
-                                    <SelectItem key={i} value={i}>{i}</SelectItem>
-                                  ))}
+                                : (intakeOptions.length
+                                  ? intakeOptions.map((opt) => (
+                                      <SelectItem key={String(opt.value)} value={opt.label}>{opt.label}</SelectItem>
+                                    ))
+                                  : ((uniDetail?.admissionRequirements?.intakes || []) as string[]).map((i) => (
+                                      <SelectItem key={i} value={i}>{i}</SelectItem>
+                                    ))
+                                  )}
                             </SelectContent>
                           </Select>
                         </FormControl>


### PR DESCRIPTION
## Purpose

Users reported that while `course_id` (courseId) was being populated correctly, the `intake_id` (intakeId) field remained empty when creating applications. The intake data needed to be properly sourced from the `university_intakes` table to ensure both the intake label and corresponding ID are captured during application creation.

## Code changes

### Backend (University.ts)
- Modified university intakes query to select both `id` and `intakeLabel` fields instead of just `intakeLabel`
- Added new `intakesWithIds` field to university response containing intake objects with both ID and label

### Frontend (add-application-modal.tsx & add-application.tsx)
- Updated intake selection logic to use `intakesWithIds` data from university details
- Added automatic `intakeId` population when intake is selected by finding matching intake object
- Enhanced form reset logic to clear both `courseId` and `intakeId` when dependencies change
- Added proper error handling for intake ID lookup
- Implemented fallback to legacy intake list if `intakesWithIds` is not available

### Form handling improvements
- Added `courseId` and `intakeId` to form reset operations when university/course type changes
- Enhanced course selection to automatically populate `courseId` from course data
- Improved intake selection to automatically populate `intakeId` from university intake dataTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 127`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1328ea8eb46f493baed6484c6b2202d5/echo-oasis)

👀 [Preview Link](https://1328ea8eb46f493baed6484c6b2202d5-echo-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1328ea8eb46f493baed6484c6b2202d5</projectId>-->
<!--<branchName>echo-oasis</branchName>-->