### PR TITLE
Fix event form validation and save button styling

### DIFF
--- a/backend/src/services/LeadService.ts
+++ b/backend/src/services/LeadService.ts
@@ -214,6 +214,9 @@ export class LeadService {
                 String(newValue ?? ''),
                 currentUserId
               );
+              if (lead) {
+                void NotificationService.queueLeadLostNotification(lead);
+              }
             } else if (!becameLost && wasLost) {
               await ActivityService.logActivity(
                 'lead',

--- a/backend/src/services/NotificationService.ts
+++ b/backend/src/services/NotificationService.ts
@@ -3,6 +3,7 @@ import { NotificationModel, type InsertNotification } from "../models/Notificati
 import { type Lead } from "../shared/schema.js";
 
 const LEAD_CREATION_TEMPLATE_ID = "nxtcrm_lead_creation";
+const LEAD_LOST_TEMPLATE_ID = "nxtcrm_lead_lost";
 
 export type QueueNotificationInput = {
   entityType: string;
@@ -58,6 +59,28 @@ export class NotificationService {
       });
     } catch (error) {
       console.error("[NotificationService] Failed to queue lead creation notification:", error);
+    }
+  }
+
+  static async queueLeadLostNotification(lead: Lead): Promise<void> {
+    try {
+      if (!lead?.id) {
+        return;
+      }
+
+      await NotificationService.queueNotification({
+        entityType: "lead",
+        entityId: lead.id,
+        templateId: LEAD_LOST_TEMPLATE_ID,
+        channel: "whatsapp",
+        variables: {
+          lead_name: lead.name ?? "",
+          lost_reason: (lead as any)?.lostReason ?? "",
+        },
+        recipientAddress: lead.phone ?? null,
+      });
+    } catch (error) {
+      console.error("[NotificationService] Failed to queue lead lost notification:", error);
     }
   }
 }

--- a/frontend/src/components/lead-details-modal.tsx
+++ b/frontend/src/components/lead-details-modal.tsx
@@ -305,6 +305,11 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
 
   if (!lead) return null;
 
+  const isLost = (() => {
+    const v: any = (lead as any)?.isLost;
+    return v === 1 || v === '1' || v === true;
+  })();
+
   const lostReasonOptions = [
     { label: 'No Response', value: 'no_response' },
     { label: 'Not Interested', value: 'not_interested' },
@@ -347,10 +352,6 @@ export function LeadDetailsModal({ open, onOpenChange, lead, onLeadUpdate, onOpe
   );
 
   const processedLeadForDisplay = lead ? { ...lead, country: parseFieldValue(lead.country), program: parseFieldValue(lead.program) } : {} as any;
-  const isLost = (() => {
-    const v: any = (lead as any)?.isLost;
-    return v === 1 || v === '1' || v === true;
-  })();
   const displayData = isEditing ? (editData as any) : processedLeadForDisplay;
 
   const headerLeft = (

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1894,7 +1894,19 @@ export default function EventsPage() {
                   </div>
                   <div>
                     <Label>Venue</Label>
-                    <Input value={editEvent.venue} onChange={(e) => setEditEvent({ ...editEvent, venue: e.target.value })} />
+                    <Input
+                      value={editEvent.venue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
+                        const singleSpaced = sanitized.replace(/\s+/g, ' ');
+                        const trimmed = singleSpaced.replace(/^\s+/, '');
+                        const title = trimmed.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        setEditEvent({ ...editEvent, venue: title });
+                      }}
+                      inputMode="text"
+                      pattern="[A-Za-z]+(?: [A-Za-z]+)*"
+                    />
                   </div>
                 </div>
               </CollapsibleCard>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -2014,7 +2014,19 @@ export default function EventsPage() {
                   </div>
                   <div>
                     <Label>Type</Label>
-                    <Input value={newEvent.type} onChange={(e) => setNewEvent({ ...newEvent, type: e.target.value })} />
+                    <Input
+                      value={newEvent.type}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
+                        const singleSpaced = sanitized.replace(/\s+/g, ' ');
+                        const trimmed = singleSpaced.replace(/^\s+/, '');
+                        const title = trimmed.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        setNewEvent({ ...newEvent, type: title });
+                      }}
+                      inputMode="text"
+                      pattern="[A-Za-z]+(?: [A-Za-z]+)*"
+                    />
                   </div>
                   <div>
                     <Label>Date & Time</Label>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1949,7 +1949,7 @@ export default function EventsPage() {
           headerRight={(
             <Button
               size="xs"
-              className="px-3 mr-2 [&_svg]:size-3 bg-white text-black hover:bg-gray-100 border border-gray-300 rounded-md"
+              className="px-3 mr-2 [&_svg]:size-3 bg-[#0071B0] hover:bg-[#00649D] text-white"
               onClick={handleCreateEvent}
               disabled={addEventMutation.isPending}
             >

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1973,9 +1973,12 @@ export default function EventsPage() {
                       value={newEvent.name}
                       onChange={(e) => {
                         const v = e.target.value;
-                        const title = v.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
+                        const title = sanitized.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
                         setNewEvent({ ...newEvent, name: title });
                       }}
+                      inputMode="text"
+                      pattern="[A-Za-z ]*"
                     />
                   </div>
                   <div>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1853,11 +1853,13 @@ export default function EventsPage() {
                       onChange={(e) => {
                         const v = e.target.value;
                         const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
-                        const title = sanitized.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        const singleSpaced = sanitized.replace(/\s+/g, ' ');
+                        const trimmed = singleSpaced.replace(/^\s+/, '');
+                        const title = trimmed.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
                         setEditEvent({ ...editEvent, name: title });
                       }}
                       inputMode="text"
-                      pattern="[A-Za-z ]*"
+                      pattern="[A-Za-z]+(?: [A-Za-z]+)*"
                     />
                   </div>
                   <div>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1977,11 +1977,13 @@ export default function EventsPage() {
                       onChange={(e) => {
                         const v = e.target.value;
                         const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
-                        const title = sanitized.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        const singleSpaced = sanitized.replace(/\s+/g, ' ');
+                        const trimmed = singleSpaced.replace(/^\s+/, '');
+                        const title = trimmed.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
                         setNewEvent({ ...newEvent, name: title });
                       }}
                       inputMode="text"
-                      pattern="[A-Za-z ]*"
+                      pattern="[A-Za-z]+(?: [A-Za-z]+)*"
                     />
                   </div>
                   <div>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -2047,7 +2047,19 @@ export default function EventsPage() {
                   </div>
                   <div>
                     <Label>Venue</Label>
-                    <Input value={newEvent.venue} onChange={(e) => setNewEvent({ ...newEvent, venue: e.target.value })} />
+                    <Input
+                      value={newEvent.venue}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
+                        const singleSpaced = sanitized.replace(/\s+/g, ' ');
+                        const trimmed = singleSpaced.replace(/^\s+/, '');
+                        const title = trimmed.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        setNewEvent({ ...newEvent, venue: title });
+                      }}
+                      inputMode="text"
+                      pattern="[A-Za-z]+(?: [A-Za-z]+)*"
+                    />
                   </div>
                 </div>
               </CollapsibleCard>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1890,6 +1890,9 @@ export default function EventsPage() {
                         const [d, t] = v.split('T');
                         setEditEvent({ ...editEvent, date: d || '', time: (t || '').slice(0, 5) });
                       }}
+                      readOnly
+                      onFocus={(e) => e.target.showPicker?.()}
+                      onClick={(e) => e.currentTarget.showPicker?.()}
                     />
                   </div>
                   <div>
@@ -2043,6 +2046,9 @@ export default function EventsPage() {
                         const [d, t] = v.split('T');
                         setNewEvent({ ...newEvent, date: d || '', time: (t || '').slice(0, 5) });
                       }}
+                      readOnly
+                      onFocus={(e) => e.target.showPicker?.()}
+                      onClick={(e) => e.currentTarget.showPicker?.()}
                     />
                   </div>
                   <div>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1864,7 +1864,19 @@ export default function EventsPage() {
                   </div>
                   <div>
                     <Label>Type</Label>
-                    <Input value={editEvent.type} onChange={(e) => setEditEvent({ ...editEvent, type: e.target.value })} />
+                    <Input
+                      value={editEvent.type}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
+                        const singleSpaced = sanitized.replace(/\s+/g, ' ');
+                        const trimmed = singleSpaced.replace(/^\s+/, '');
+                        const title = trimmed.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        setEditEvent({ ...editEvent, type: title });
+                      }}
+                      inputMode="text"
+                      pattern="[A-Za-z]+(?: [A-Za-z]+)*"
+                    />
                   </div>
                   <div>
                     <Label>Date & Time</Label>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -2010,6 +2010,7 @@ export default function EventsPage() {
                 persistKey={`events:new:access`}
                 header={<CardTitle className="flex items-center space-x-2"><MapPin className="w-4 h-4 text-primary" /><span>Event Access</span></CardTitle>}
                 cardClassName="shadow-md border border-gray-200 bg-white"
+                defaultOpen
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   <div>

--- a/frontend/src/pages/events.tsx
+++ b/frontend/src/pages/events.tsx
@@ -1852,9 +1852,12 @@ export default function EventsPage() {
                       value={editEvent.name}
                       onChange={(e) => {
                         const v = e.target.value;
-                        const title = v.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
+                        const sanitized = v.replace(/[^a-zA-Z\s]/g, '');
+                        const title = sanitized.replace(/(^|\s)([a-z])/g, (_m, p1, p2) => p1 + String(p2).toUpperCase());
                         setEditEvent({ ...editEvent, name: title });
                       }}
+                      inputMode="text"
+                      pattern="[A-Za-z ]*"
                     />
                   </div>
                   <div>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI/UX issues with the events form:
- Standardize save button styling to match lead save button
- Implement proper text validation for event fields (name, type, venue) allowing only alphabets and spaces
- Prevent leading spaces and multiple consecutive spaces in text inputs
- Disable keyboard input for date/time fields, forcing users to use the date picker popup

## Code changes

### Frontend Changes
- **Event form validation**: Added comprehensive input sanitization for name, type, and venue fields that removes non-alphabetic characters, prevents leading spaces, and collapses multiple spaces
- **Save button styling**: Updated save button to use consistent blue theme (`bg-[#0071B0]`) instead of white/gray styling
- **Date/time input**: Made datetime inputs read-only with automatic picker opening on focus/click
- **Lead details modal**: Moved `isLost` calculation earlier in component for better code organization

### Backend Changes
- **Lead lost notifications**: Added new notification service method `queueLeadLostNotification()` that triggers WhatsApp notifications when leads are marked as lost
- **Lead service integration**: Integrated lead lost notifications into the lead update workflow

### Technical Details
- Text validation uses regex to sanitize input: `/[^a-zA-Z\s]/g` for character filtering and `/\s+/g` for space normalization
- Date inputs use `showPicker()` API for consistent date selection experience
- Notification system expanded with `LEAD_LOST_TEMPLATE_ID` template supportTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 133`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2b5898478e7a4ff1993c85aa80ba5fb1/flare-verse)

👀 [Preview Link](https://2b5898478e7a4ff1993c85aa80ba5fb1-flare-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2b5898478e7a4ff1993c85aa80ba5fb1</projectId>-->
<!--<branchName>flare-verse</branchName>-->