### PR TITLE
Add student picker modal for application creation

### DIFF
--- a/frontend/src/components/admission-details-modal-new.tsx
+++ b/frontend/src/components/admission-details-modal-new.tsx
@@ -300,17 +300,19 @@ export function AdmissionDetailsModal({ open, onOpenChange, admission }: Admissi
     </div>
   ) : (
     <div className="flex items-center gap-2">
-      <Button
-        variant="outline"
-        size="xs"
-        className="px-3 [&_svg]:size-3 bg-white text-black hover:bg-gray-100 border border-gray-300 rounded-md"
-        onClick={() => {
-          try { setLocation(`/admissions/${admission.id}/edit`); } catch { }
-        }}
-        title="Edit Admission"
-      >
-        Edit
-      </Button>
+      {canEditAdmission && (
+        <Button
+          variant="outline"
+          size="xs"
+          className="px-3 [&_svg]:size-3 bg-white text-black hover:bg-gray-100 border border-gray-300 rounded-md"
+          onClick={() => {
+            try { setLocation(`/admissions/${admission.id}/edit`); } catch { }
+          }}
+          title="Edit Admission"
+        >
+          Edit
+        </Button>
+      )}
 
       <Button
         variant="ghost"
@@ -564,7 +566,7 @@ export function AdmissionDetailsModal({ open, onOpenChange, admission }: Admissi
                     {(() => {
                       const cid = (admission as any)?.counsellorId || (admission as any)?.counselorId || (student as any)?.counselorId || (student as any)?.counsellorId;
                       const c = cid && Array.isArray(users) ? (users as any[]).find((u: any) => String(u.id) === String(cid)) : null;
-                      if (!c) return '��';
+                      if (!c) return '—';
                       const fullName = [c.firstName || c.first_name, c.lastName || c.last_name].filter(Boolean).join(' ').trim();
                       const email = c.email || '';
                       return (

--- a/frontend/src/components/admission-details-modal-new.tsx
+++ b/frontend/src/components/admission-details-modal-new.tsx
@@ -18,6 +18,8 @@ import * as BranchesService from '@/services/branches';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useState, useEffect, useMemo } from "react";
 import { useLocation, useRoute } from 'wouter';
+import { useAuth } from '@/contexts/AuthContext';
+import { toast } from '@/hooks/use-toast';
 
 interface AdmissionDetailsModalProps {
   open: boolean;
@@ -28,7 +30,23 @@ interface AdmissionDetailsModalProps {
 export function AdmissionDetailsModal({ open, onOpenChange, admission }: AdmissionDetailsModalProps) {
   const [, setLocation] = useLocation();
   const [matchEdit] = useRoute('/admissions/:id/edit');
-  const isEdit = !!matchEdit;
+
+  const { accessByRole } = useAuth() as any;
+  const normalizeModule = (s: string) => String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  const singularize = (s: string) => String(s || '').replace(/s$/i, '');
+  const canEditAdmission = useMemo(() => {
+    const entries = (Array.isArray(accessByRole) ? accessByRole : []).filter((a: any) => singularize(normalizeModule(a.moduleName ?? a.module_name)) === 'admission');
+    if (entries.length === 0) return true;
+    return entries.some((e: any) => (e.canEdit ?? e.can_edit) === true || (e.canUpdate ?? e.can_update) === true || (e.edit ?? e.update) === true || e.canEdit === 1 || e.can_update === 1);
+  }, [accessByRole]);
+
+  const isEdit = !!(matchEdit && canEditAdmission);
+
+  useEffect(() => {
+    if (matchEdit && !canEditAdmission && admission?.id) {
+      try { setLocation(`/admissions/${admission.id}`); } catch {}
+    }
+  }, [matchEdit, canEditAdmission, admission?.id, setLocation]);
 
   const { data: admissionDropdowns } = useQuery<Record<string, any[]>>({
     queryKey: ['/api/dropdowns/module/Admissions'],

--- a/frontend/src/components/admission-details-modal-new.tsx
+++ b/frontend/src/components/admission-details-modal-new.tsx
@@ -192,6 +192,10 @@ export function AdmissionDetailsModal({ open, onOpenChange, admission }: Admissi
   });
 
   const handleStatusChange = (newStatus: string) => {
+    if (!canEditAdmission) {
+      toast({ title: 'You do not have permission to edit admissions', variant: 'destructive' });
+      return;
+    }
     setCurrentStatus(newStatus);
     updateStatusMutation.mutate(newStatus);
   };
@@ -560,7 +564,7 @@ export function AdmissionDetailsModal({ open, onOpenChange, admission }: Admissi
                     {(() => {
                       const cid = (admission as any)?.counsellorId || (admission as any)?.counselorId || (student as any)?.counselorId || (student as any)?.counsellorId;
                       const c = cid && Array.isArray(users) ? (users as any[]).find((u: any) => String(u.id) === String(cid)) : null;
-                      if (!c) return '—';
+                      if (!c) return '��';
                       const fullName = [c.firstName || c.first_name, c.lastName || c.last_name].filter(Boolean).join(' ').trim();
                       const email = c.email || '';
                       return (

--- a/frontend/src/pages/add-application.tsx
+++ b/frontend/src/pages/add-application.tsx
@@ -330,11 +330,13 @@ export default function AddApplication() {
         />
 
         <Dialog open={studentPickerOpen} onOpenChange={(o) => { setStudentPickerOpen(o); if (!o && !selectedStudentIdForModal && !presetStudentId) setLocation('/applications'); }}>
-          <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Select a student to create application</DialogTitle>
+          <DialogContent className="max-w-2xl overflow-hidden p-0">
+          <DialogHeader className="p-0">
+            <div className="px-4 py-3 bg-[#223E7D] text-white">
+              <DialogTitle className="text-white">Select a student to create application</DialogTitle>
+            </div>
           </DialogHeader>
-          <div className="space-y-3">
+          <div className="space-y-3 p-4">
             <div className="flex items-center gap-2">
               <Input
                 placeholder="Search by name, ID, or contact"

--- a/frontend/src/pages/add-application.tsx
+++ b/frontend/src/pages/add-application.tsx
@@ -15,7 +15,7 @@ import { useToast } from '@/hooks/use-toast';
 import { HelpTooltipSimple as HelpTooltip } from '@/components/help-tooltip-simple';
 import * as UniversitiesService from '@/services/universities';
 import * as UsersService from '@/services/users';
-import { School, FileText, Globe, Briefcase, Link as LinkIcon, ArrowLeft, PlusCircle, GraduationCap, Save, Users } from 'lucide-react';
+import { School, FileText, Globe, Briefcase, Link as LinkIcon, ArrowLeft, PlusCircle, GraduationCap, Save, Users, X } from 'lucide-react';
 import * as DropdownsService from '@/services/dropdowns';
 import { http } from '@/services/http';
 import { useMemo, useEffect, useState } from 'react';
@@ -332,8 +332,17 @@ export default function AddApplication() {
         <Dialog open={studentPickerOpen} onOpenChange={(o) => { setStudentPickerOpen(o); if (!o && !selectedStudentIdForModal && !presetStudentId) setLocation('/applications'); }}>
           <DialogContent className="max-w-2xl overflow-hidden p-0">
           <DialogHeader className="p-0">
-            <div className="px-4 py-3 bg-[#223E7D] text-white">
+            <div className="px-4 py-3 bg-[#223E7D] text-white flex items-center justify-between">
               <DialogTitle className="text-white">Select a student to create application</DialogTitle>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="w-8 h-8 rounded-full bg-white text-black hover:bg-gray-100 border border-gray-300"
+                onClick={() => { setStudentPickerOpen(false); }}
+                aria-label="Close"
+              >
+                <X className="w-4 h-4" />
+              </Button>
             </div>
           </DialogHeader>
           <div className="space-y-3 p-4">
@@ -389,9 +398,6 @@ export default function AddApplication() {
                   })()}
                 </TableBody>
               </Table>
-            </div>
-            <div className="flex justify-end gap-2 mt-2">
-              <Button variant="outline" onClick={() => setLocation('/applications')}>Cancel</Button>
             </div>
           </div>
         </DialogContent>


### PR DESCRIPTION
## Purpose

The user wanted to implement a student selection workflow for creating applications, similar to the existing students page functionality. They requested:
- A create button on the /applications page (like /students)
- A student picker modal that appears before the application form
- The modal should show student listings with search functionality
- Once a student is selected, it should populate the application form with their data
- UI improvements including a blueish header and proper close button styling

## Code changes

- **Added create button to applications page**: Implemented an animated "+" button with role-based permissions checking
- **Created student picker modal**: Added a dialog with student listing table showing ID, name, contact, and select buttons
- **Implemented search functionality**: Added search input that filters students by name, ID, and contact across 4 records
- **Added modal styling**: Applied blueish header background (#223E7D) and replaced default close with custom X button in circle
- **Enhanced permission controls**: Added role-based access control for editing admissions and creating applications
- **Improved navigation flow**: Modified add-application page to show student picker first, then application form with pre-filled student data
- **Added loading states**: Implemented navigation loading indicators with spinning animations

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 143`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3520f40269ff4c769bb996a6c2f3f4d8/cosmos-space)

👀 [Preview Link](https://3520f40269ff4c769bb996a6c2f3f4d8-cosmos-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3520f40269ff4c769bb996a6c2f3f4d8</projectId>-->
<!--<branchName>cosmos-space</branchName>-->