### PR TITLE
Add time picker for follow-up scheduling

### DIFF
--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { HelpTooltip } from "./help-tooltip";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";

--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -55,6 +55,41 @@ export function ActivityTracker({ entityType, entityId, entityName, initialInfo,
     return base;
   }, []);
 
+  const computeDefaultFollowUpTime = React.useCallback((selected: Date) => {
+    const now = new Date();
+    if (selected.toDateString() === now.toDateString()) {
+      const nextSlot = addMinutes(now, 30);
+      nextSlot.setSeconds(0, 0);
+      return format(nextSlot, "HH:mm");
+    }
+    return "09:00";
+  }, []);
+
+  const followUpDateTime = React.useMemo(() => {
+    if (!followUpDate) return undefined;
+    if (!followUpTime) return undefined;
+    const [hoursStr, minutesStr] = followUpTime.split(":");
+    const hours = Number(hoursStr);
+    const minutes = Number(minutesStr);
+    if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+      return undefined;
+    }
+    const combined = new Date(followUpDate.getTime());
+    combined.setHours(hours, minutes, 0, 0);
+    return combined;
+  }, [followUpDate, followUpTime]);
+
+  const minTimeForSelectedDate = React.useMemo(() => {
+    if (!followUpDate) return undefined;
+    const now = new Date();
+    if (followUpDate.toDateString() !== now.toDateString()) {
+      return undefined;
+    }
+    const hours = String(now.getHours()).padStart(2, "0");
+    const minutes = String(now.getMinutes()).padStart(2, "0");
+    return `${hours}:${minutes}`;
+  }, [followUpDate]);
+
   const handleActivityTypeChange = (value: string) => {
     setActivityType(value);
     if (value !== 'follow_up') {

--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -395,6 +395,7 @@ export function ActivityTracker({ entityType, entityId, entityName, initialInfo,
       setNewActivity('');
       setActivityType('comment');
       setFollowUpDate(undefined);
+      setFollowUpTime('');
       setComposerError(null);
       setIsAddingActivity(false);
       return { previous, tempId };

--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -17,7 +17,7 @@ import * as DropdownsService from "@/services/dropdowns";
 import * as ActivitiesService from "@/services/activities";
 import * as UsersService from '@/services/users';
 import * as LeadsService from '@/services/leads';
-import { format } from "date-fns";
+import { addMinutes, format } from "date-fns";
 import { useAuth } from '@/contexts/AuthContext';
 import { createPortal } from 'react-dom';
 import { useLocation } from 'wouter';

--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -420,15 +420,21 @@ export function ActivityTracker({ entityType, entityId, entityName, initialInfo,
     if (!content) {
       return;
     }
-    if (activityType === 'follow_up' && !followUpDate) {
-      setComposerError('Select a follow-up date');
-      return;
+    if (activityType === 'follow_up') {
+      if (!followUpDate || !followUpTime || !followUpDateTime) {
+        setComposerError('Select follow-up date and time');
+        return;
+      }
+      if (followUpDateTime.getTime() < Date.now()) {
+        setComposerError('Follow-up must be scheduled in the future');
+        return;
+      }
     }
     setComposerError(null);
     addActivityMutation.mutate({
       type: activityType,
       content,
-      followUpAt: followUpDate ? followUpDate.toISOString() : null,
+      followUpAt: followUpDateTime ? followUpDateTime.toISOString() : null,
     });
   };
 

--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -59,6 +59,7 @@ export function ActivityTracker({ entityType, entityId, entityName, initialInfo,
     setActivityType(value);
     if (value !== 'follow_up') {
       setFollowUpDate(undefined);
+      setFollowUpTime("");
     }
     setComposerError(null);
   };

--- a/frontend/src/components/activity-tracker.tsx
+++ b/frontend/src/components/activity-tracker.tsx
@@ -43,6 +43,7 @@ export function ActivityTracker({ entityType, entityId, entityName, initialInfo,
   const [newActivity, setNewActivity] = useState("");
   const [activityType, setActivityType] = useState("comment");
   const [followUpDate, setFollowUpDate] = useState<Date | undefined>(undefined);
+  const [followUpTime, setFollowUpTime] = useState("");
   const [composerError, setComposerError] = useState<string | null>(null);
   const [isAddingActivity, setIsAddingActivity] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);


### PR DESCRIPTION
## Purpose
The user requested that follow-up activities must include a datetime instead of just a date. This enhancement allows users to schedule follow-ups with specific times, providing more precise scheduling capabilities for activity tracking.

## Code changes
- Added time input field for follow-up scheduling alongside the existing date picker
- Implemented `followUpDateTime` computation that combines selected date and time
- Added validation to ensure follow-up datetime is in the future
- Enhanced follow-up display to show both date and time when available
- Added smart default time calculation (30 minutes from now for today, 9:00 AM for future dates)
- Updated error handling to require both date and time for follow-up activities
- Improved follow-up date formatting with `safeFormatFollowUpDate` function

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 152`

🔗 [Edit in Builder.io](https://builder.io/app/projects/52ccbf9e3d054a80ab6f9cbe224efa25/curry-verse)

👀 [Preview Link](https://52ccbf9e3d054a80ab6f9cbe224efa25-curry-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>52ccbf9e3d054a80ab6f9cbe224efa25</projectId>-->
<!--<branchName>curry-verse</branchName>-->