### PR TITLE
Add calendar modal with day/week/month/year views

### DIFF
--- a/backend/src/shared/schema.ts
+++ b/backend/src/shared/schema.ts
@@ -12,6 +12,27 @@ const NotificationStatusEnum = mysqlEnum("status", [
   "failed",
 ]);
 
+export const followUps = mysqlTable("follow_ups", {
+  id: varchar("id", { length: 36 }).primaryKey().notNull(),
+  userId: varchar("user_id", { length: 36 }).notNull(),
+  entityId: varchar("entity_id", { length: 36 }).notNull(),
+  entityType: varchar("entity_type", { length: 36 }).notNull(), // fixed spelling from `entitiy_type`
+  comments: text("comments").notNull(),
+  followUpOn: timestamp("followup_on").notNull(),
+  createdOn: timestamp("created_on").defaultNow().notNull(),
+  updatedOn: timestamp("updated_on").defaultNow().notNull(),
+});
+
+// Insert schema for followUps
+export const insertFollowUpSchema = createInsertSchema(followUps).omit({
+  createdOn: true,
+  updatedOn: true,
+}).partial({ id: true });
+
+export type FollowUp = typeof followUps.$inferSelect;
+export type InsertFollowUp = z.infer<typeof insertFollowUpSchema>;
+
+
 export const usersResetTokens = mysqlTable("users_reset_token", {
   id: varchar("id", { length: 36 }).primaryKey().notNull(),
   userId: varchar("user_id", { length: 36 }).notNull(),

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -241,14 +241,14 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
       case 'month':
         return (
           <div className="flex h-full w-full flex-col items-center overflow-auto">
-            <div className="w-full max-w-4xl rounded-lg border bg-white shadow-sm">
+            <div className="rounded-lg border bg-white shadow-sm">
               <Calendar
                 mode="single"
                 month={monthForCalendar}
                 onMonthChange={(date) => setFocusDate(startOfMonth(date))}
                 selected={selectedDate}
                 onSelect={handleSelectDay}
-                className="bg-transparent"
+                className="bg-transparent p-4"
               />
             </div>
           </div>

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -291,9 +291,9 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         hideClose
-        className="fixed inset-0 left-0 top-0 m-0 h-screen w-screen translate-x-0 translate-y-0 rounded-none border-0 bg-white p-0 shadow-none sm:rounded-none"
+        className="sm:max-w-5xl w-[95vw] max-h-[90vh] overflow-hidden border-0 bg-white p-0 shadow-xl"
       >
-        <div className="flex h-full flex-col">
+        <div className="flex h-full max-h-[90vh] flex-col">
           <div className="flex flex-col gap-3 border-b px-4 py-3 sm:px-6">
             <div className="flex items-start justify-between gap-3">
               <div>

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+
+interface CalendarModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange }) => {
+  const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(new Date());
+  const [currentMonth, setCurrentMonth] = React.useState<Date>(new Date());
+
+  React.useEffect(() => {
+    if (!open) {
+      const now = new Date();
+      setSelectedDate(now);
+      setCurrentMonth(now);
+    }
+  }, [open]);
+
+  const monthLabel = React.useMemo(
+    () => new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' }).format(currentMonth),
+    [currentMonth],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        hideClose
+        className="fixed inset-0 left-0 top-0 m-0 h-screen w-screen translate-x-0 translate-y-0 rounded-none border-0 bg-white p-0 shadow-none sm:rounded-none"
+      >
+        <div className="flex h-full flex-col">
+          <div className="flex items-start justify-between gap-3 border-b px-4 py-3 sm:px-6">
+            <div>
+              <DialogTitle className="text-lg font-semibold text-gray-900 sm:text-xl">Calendar</DialogTitle>
+              <DialogDescription className="text-sm text-muted-foreground">
+                Browse dates and plan upcoming activities.
+              </DialogDescription>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+          </div>
+
+          <div className="flex flex-1 flex-col items-center overflow-auto px-3 py-6 sm:px-6">
+            <div className="text-base font-medium text-gray-700 sm:text-lg" aria-live="polite">
+              {monthLabel}
+            </div>
+            <div className="mt-4 rounded-lg border bg-white shadow-sm">
+              <Calendar
+                mode="single"
+                month={currentMonth}
+                onMonthChange={setCurrentMonth}
+                selected={selectedDate}
+                onSelect={setSelectedDate}
+                className="bg-transparent"
+              />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -253,35 +253,71 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
             </div>
           </div>
         );
-      case 'year':
+      case 'year': {
+        const currentMonth = new Date();
         return (
-          <div className="flex h-full w-full flex-col items-center overflow-auto">
-            <div className="w-full max-w-4xl">
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          <div className="flex h-full w-full flex-col items-center overflow-auto px-1">
+            <div className="w-full max-w-5xl">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
                 {yearMonths.map((month) => {
-                  const isSelected = isSameMonth(month, selectedDate);
+                  const isSelectedMonth = isSameMonth(month, selectedDate);
+                  const isCurrentMonth = isSameMonth(month, currentMonth);
                   return (
-                    <button
+                    <div
                       key={month.toISOString()}
-                      type="button"
-                      onClick={() => {
-                        setFocusDate(month);
-                        setView('month');
-                      }}
                       className={cn(
-                        'rounded-lg border bg-white p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
-                        isSelected ? 'border-primary bg-primary/10' : 'border-gray-200 hover:border-primary/60 hover:bg-primary/5',
+                        'flex flex-col rounded-xl border bg-white p-3 shadow-sm transition',
+                        isSelectedMonth
+                          ? 'border-primary shadow-md'
+                          : 'border-gray-200 hover:border-primary/60 hover:shadow',
                       )}
                     >
-                      <div className="text-lg font-semibold text-gray-900">{format(month, 'MMMM')}</div>
-                      <div className="mt-1 text-xs text-muted-foreground">{format(month, 'yyyy')}</div>
-                    </button>
+                      <div className="flex items-center justify-between">
+                        <div className="text-sm font-semibold text-gray-900">{format(month, 'MMMM')}</div>
+                        <div className="text-xs text-muted-foreground">{format(month, 'yyyy')}</div>
+                      </div>
+                      <Calendar
+                        mode="single"
+                        disableNavigation
+                        showOutsideDays
+                        month={month}
+                        selected={selectedDate}
+                        onSelect={(date) => {
+                          if (!date) {
+                            return;
+                          }
+                          setSelectedDate(date);
+                          setFocusDate(startOfMonth(date));
+                          setView('month');
+                        }}
+                        className="mt-2 w-full self-center rounded-lg border bg-transparent p-2"
+                        classNames={{
+                          nav: 'hidden',
+                          caption: 'hidden',
+                          months: 'flex flex-col',
+                          month: 'space-y-2',
+                          table: 'w-full border-collapse space-y-0',
+                          head_row: 'flex',
+                          head_cell: 'text-[11px] font-semibold uppercase tracking-wide text-muted-foreground',
+                          row: 'flex w-full mt-1',
+                          cell: 'h-7 w-7 p-0 text-center text-xs',
+                          day: 'h-7 w-7 rounded-full text-xs transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                          day_selected:
+                            'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+                          day_today: cn(
+                            'border border-primary text-primary',
+                            isCurrentMonth ? 'border-primary' : 'border-primary/60',
+                          ),
+                        }}
+                      />
+                    </div>
                   );
                 })}
               </div>
             </div>
           </div>
         );
+      }
       default:
         return null;
     }

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -245,7 +245,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
               <Calendar
                 mode="single"
                 month={monthForCalendar}
-                onMonthChange={(date) => setFocusDate(date)}
+                onMonthChange={(date) => setFocusDate(startOfMonth(date))}
                 selected={selectedDate}
                 onSelect={handleSelectDay}
                 className="bg-transparent"

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -258,7 +258,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
         return (
           <div className="flex h-full w-full flex-col items-center overflow-auto px-1">
             <div className="w-full max-w-5xl">
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 {yearMonths.map((month) => {
                   const isSelectedMonth = isSameMonth(month, selectedDate);
                   const isCurrentMonth = isSameMonth(month, currentMonth);

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -2,28 +2,290 @@ import React from 'react';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
+import { cn } from '@/lib/utils';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  addDays,
+  addMonths,
+  addYears,
+  eachDayOfInterval,
+  eachMonthOfInterval,
+  endOfWeek,
+  endOfYear,
+  format,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+  subDays,
+  subMonths,
+  subYears,
+} from 'date-fns';
 
 interface CalendarModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+type CalendarView = 'day' | 'week' | 'month' | 'year';
+
+const viewOptions: { value: CalendarView; label: string }[] = [
+  { value: 'day', label: 'Day' },
+  { value: 'week', label: 'Week' },
+  { value: 'month', label: 'Month' },
+  { value: 'year', label: 'Year' },
+];
+
 export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange }) => {
-  const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(new Date());
-  const [currentMonth, setCurrentMonth] = React.useState<Date>(new Date());
+  const [selectedDate, setSelectedDate] = React.useState<Date>(new Date());
+  const [focusDate, setFocusDate] = React.useState<Date>(new Date());
+  const [view, setView] = React.useState<CalendarView>('month');
 
   React.useEffect(() => {
     if (!open) {
       const now = new Date();
       setSelectedDate(now);
-      setCurrentMonth(now);
+      setFocusDate(now);
+      setView('month');
     }
   }, [open]);
 
-  const monthLabel = React.useMemo(
-    () => new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' }).format(currentMonth),
-    [currentMonth],
-  );
+  React.useEffect(() => {
+    if (view === 'day' || view === 'week') {
+      setFocusDate(selectedDate);
+    }
+    if (view === 'month') {
+      setFocusDate((prev) => {
+        if (
+          prev.getFullYear() === selectedDate.getFullYear() &&
+          prev.getMonth() === selectedDate.getMonth()
+        ) {
+          return prev;
+        }
+        return startOfMonth(selectedDate);
+      });
+    }
+    if (view === 'year') {
+      setFocusDate((prev) => {
+        if (prev.getFullYear() === selectedDate.getFullYear()) {
+          return prev;
+        }
+        return selectedDate;
+      });
+    }
+  }, [view, selectedDate]);
+
+  const monthForCalendar = React.useMemo(() => startOfMonth(focusDate), [focusDate]);
+
+  const weekDays = React.useMemo(() => {
+    const start = startOfWeek(focusDate, { weekStartsOn: 1 });
+    const end = endOfWeek(focusDate, { weekStartsOn: 1 });
+    return eachDayOfInterval({ start, end });
+  }, [focusDate]);
+
+  const yearMonths = React.useMemo(() => {
+    const start = startOfYear(focusDate);
+    const end = endOfYear(focusDate);
+    return eachMonthOfInterval({ start, end });
+  }, [focusDate]);
+
+  const hourSlots = React.useMemo(() => Array.from({ length: 24 }, (_, idx) => idx), []);
+
+  const viewLabel = React.useMemo(() => {
+    switch (view) {
+      case 'day':
+        return format(focusDate, 'EEEE, MMMM d, yyyy');
+      case 'week': {
+        const start = startOfWeek(focusDate, { weekStartsOn: 1 });
+        const end = endOfWeek(focusDate, { weekStartsOn: 1 });
+        const sameMonth = start.getMonth() === end.getMonth();
+        const sameYear = start.getFullYear() === end.getFullYear();
+        const startFormat = sameYear ? (sameMonth ? 'MMM d' : 'MMM d, yyyy') : 'MMM d, yyyy';
+        const endFormat = 'MMM d, yyyy';
+        return `${format(start, startFormat)} – ${format(end, endFormat)}`;
+      }
+      case 'month':
+        return format(focusDate, 'MMMM yyyy');
+      case 'year':
+        return format(focusDate, 'yyyy');
+      default:
+        return '';
+    }
+  }, [focusDate, view]);
+
+  const handleSelectDay = React.useCallback((date?: Date) => {
+    if (!date) {
+      return;
+    }
+    setSelectedDate(date);
+    setFocusDate(date);
+  }, []);
+
+  const handlePrev = React.useCallback(() => {
+    setFocusDate((prev) => {
+      switch (view) {
+        case 'day':
+          return subDays(prev, 1);
+        case 'week':
+          return subDays(prev, 7);
+        case 'month':
+          return subMonths(prev, 1);
+        case 'year':
+          return subYears(prev, 1);
+        default:
+          return prev;
+      }
+    });
+  }, [view]);
+
+  const handleNext = React.useCallback(() => {
+    setFocusDate((prev) => {
+      switch (view) {
+        case 'day':
+          return addDays(prev, 1);
+        case 'week':
+          return addDays(prev, 7);
+        case 'month':
+          return addMonths(prev, 1);
+        case 'year':
+          return addYears(prev, 1);
+        default:
+          return prev;
+      }
+    });
+  }, [view]);
+
+  const handleToday = React.useCallback(() => {
+    const now = new Date();
+    setSelectedDate(now);
+    setFocusDate(now);
+  }, []);
+
+  const renderView = () => {
+    switch (view) {
+      case 'day':
+        return (
+          <div className="flex h-full w-full flex-col items-center overflow-auto">
+            <div className="w-full max-w-3xl px-2">
+              <div className="text-center">
+                <div className="text-3xl font-semibold text-gray-900 sm:text-4xl">
+                  {format(focusDate, 'EEEE')}
+                </div>
+                <div className="mt-1 text-sm text-muted-foreground sm:text-base">
+                  {format(focusDate, 'MMMM d, yyyy')}
+                </div>
+              </div>
+              <div className="mt-6 grid grid-cols-[auto_1fr] gap-x-4 gap-y-3">
+                {hourSlots.map((hour) => {
+                  const slotTime = new Date(
+                    focusDate.getFullYear(),
+                    focusDate.getMonth(),
+                    focusDate.getDate(),
+                    hour,
+                    0,
+                    0,
+                    0,
+                  );
+                  const label = format(slotTime, 'h a');
+                  return (
+                    <React.Fragment key={hour}>
+                      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+                      <div
+                        className="h-12 rounded-md border border-dashed border-gray-200 bg-white"
+                        role="group"
+                        aria-label={`${label} slot`}
+                      >
+                        <span className="sr-only">No events scheduled</span>
+                      </div>
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        );
+      case 'week':
+        return (
+          <div className="flex h-full w-full flex-col items-center overflow-auto">
+            <div className="w-full max-w-4xl">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7">
+                {weekDays.map((day) => {
+                  const isSelected = isSameDay(day, selectedDate);
+                  return (
+                    <button
+                      key={day.toISOString()}
+                      type="button"
+                      onClick={() => handleSelectDay(day)}
+                      className={cn(
+                        'rounded-lg border p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                        isSelected ? 'border-primary bg-primary/10' : 'border-gray-200 hover:border-primary/60 hover:bg-primary/5',
+                      )}
+                    >
+                      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {format(day, 'EEE')}
+                      </div>
+                      <div className="mt-1 text-2xl font-semibold text-gray-900">
+                        {format(day, 'd')}
+                      </div>
+                      <div className="mt-2 text-xs text-muted-foreground">
+                        {format(day, 'MMMM yyyy')}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        );
+      case 'month':
+        return (
+          <div className="flex h-full w-full flex-col items-center overflow-auto">
+            <div className="w-full max-w-4xl rounded-lg border bg-white shadow-sm">
+              <Calendar
+                mode="single"
+                month={monthForCalendar}
+                onMonthChange={(date) => setFocusDate(date)}
+                selected={selectedDate}
+                onSelect={handleSelectDay}
+                className="bg-transparent"
+              />
+            </div>
+          </div>
+        );
+      case 'year':
+        return (
+          <div className="flex h-full w-full flex-col items-center overflow-auto">
+            <div className="w-full max-w-4xl">
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                {yearMonths.map((month) => {
+                  const isSelected = isSameMonth(month, selectedDate);
+                  return (
+                    <button
+                      key={month.toISOString()}
+                      type="button"
+                      onClick={() => {
+                        setFocusDate(month);
+                        setView('month');
+                      }}
+                      className={cn(
+                        'rounded-lg border bg-white p-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                        isSelected ? 'border-primary bg-primary/10' : 'border-gray-200 hover:border-primary/60 hover:bg-primary/5',
+                      )}
+                    >
+                      <div className="text-lg font-semibold text-gray-900">{format(month, 'MMMM')}</div>
+                      <div className="mt-1 text-xs text-muted-foreground">{format(month, 'yyyy')}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -32,31 +294,64 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
         className="fixed inset-0 left-0 top-0 m-0 h-screen w-screen translate-x-0 translate-y-0 rounded-none border-0 bg-white p-0 shadow-none sm:rounded-none"
       >
         <div className="flex h-full flex-col">
-          <div className="flex items-start justify-between gap-3 border-b px-4 py-3 sm:px-6">
-            <div>
-              <DialogTitle className="text-lg font-semibold text-gray-900 sm:text-xl">Calendar</DialogTitle>
-              <DialogDescription className="text-sm text-muted-foreground">
-                Browse dates and plan upcoming activities.
-              </DialogDescription>
+          <div className="flex flex-col gap-3 border-b px-4 py-3 sm:px-6">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <DialogTitle className="text-lg font-semibold text-gray-900 sm:text-xl">Calendar</DialogTitle>
+                <DialogDescription className="text-sm text-muted-foreground">
+                  Browse dates and plan upcoming activities.
+                </DialogDescription>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
             </div>
-            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
-              Close
-            </Button>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex items-center gap-1">
+                {viewOptions.map((option) => (
+                  <Button
+                    key={option.value}
+                    size="sm"
+                    variant={view === option.value ? 'default' : 'outline'}
+                    onClick={() => setView(option.value)}
+                    aria-pressed={view === option.value}
+                  >
+                    {option.label}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="text-sm font-medium text-gray-700 sm:text-base" aria-live="polite">
+                  {viewLabel}
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handlePrev}
+                    aria-label="Previous period"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={handleToday}>
+                    Today
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleNext}
+                    aria-label="Next period"
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
           </div>
 
-          <div className="flex flex-1 flex-col items-center overflow-auto px-3 py-6 sm:px-6">
-            <div className="text-base font-medium text-gray-700 sm:text-lg" aria-live="polite">
-              {monthLabel}
-            </div>
-            <div className="mt-4 rounded-lg border bg-white shadow-sm">
-              <Calendar
-                mode="single"
-                month={currentMonth}
-                onMonthChange={setCurrentMonth}
-                selected={selectedDate}
-                onSelect={setSelectedDate}
-                className="bg-transparent"
-              />
+          <div className="flex flex-1 flex-col overflow-hidden px-3 py-6 sm:px-6">
+            <div className="flex-1 overflow-auto">
+              {renderView()}
             </div>
           </div>
         </div>

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Search, Bell, UserPlus, GraduationCap, Megaphone } from 'lucide-react';
+import { Search, Bell, UserPlus, GraduationCap, Megaphone, CalendarDays } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { UserMenu } from './user-menu';
 import { InputWithIcon } from '@/components/ui/input-with-icon';
@@ -11,6 +11,7 @@ import { AddApplicationModal } from './add-application-modal';
 import { ApplicationDetailsModal } from './application-details-modal-new';
 import { AddAdmissionModal } from './add-admission-modal';
 import { UpdatesModal } from './updates-modal';
+import { CalendarModal } from './calendar-modal';
 import { AdmissionDetailsModal } from './admission-details-modal-new';
 import { StudentProfileModal } from './student-profile-modal-new';
 import * as AdmissionsService from '@/services/admissions';
@@ -38,6 +39,7 @@ export function Header({ title, subtitle, showSearch = true, helpText }: HeaderP
   const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null);
   const { searchQuery, setSearchQuery, searchResults, isSearching } = useSearch();
   const [isUpdatesOpen, setIsUpdatesOpen] = useState(false);
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
 
   React.useEffect(() => {
     const handler = (e: any) => {
@@ -195,6 +197,17 @@ export function Header({ title, subtitle, showSearch = true, helpText }: HeaderP
               </Badge>
             </Button>
 
+            {/* Calendar */}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative h-9 w-9 rounded-full border border-gray-200 hover:bg-gray-50"
+              aria-label="Open calendar"
+              onClick={() => setIsCalendarOpen(true)}
+            >
+              <CalendarDays size={18} aria-hidden="true" />
+            </Button>
+
             {/* Notifications */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -274,6 +287,7 @@ export function Header({ title, subtitle, showSearch = true, helpText }: HeaderP
         studentId={selectedStudentId}
       />
 
+      <CalendarModal open={isCalendarOpen} onOpenChange={setIsCalendarOpen} />
       <UpdatesModal open={isUpdatesOpen} onOpenChange={setIsUpdatesOpen} />
     </>
   );


### PR DESCRIPTION
## Purpose

The user requested a comprehensive calendar interface with multiple view options (day, week, month, year) displayed in a centered popup modal. They specifically wanted:
- Calendar view options for different time periods
- A popup modal positioned in the center
- Year view showing all 12 months in a grid layout (3 months per row)
- Month view with center alignment

## Code changes

### Frontend Changes
- **Created `CalendarModal` component** with four view modes: day, week, month, and year
- **Implemented responsive grid layouts**: 3 months per row in year view, responsive week view grid
- **Added center-aligned modal** using Dialog component with proper positioning
- **Integrated calendar navigation** with previous/next buttons and "Today" functionality
- **Added calendar icon button** to header for opening the modal

### Backend Changes
- **Added `follow_ups` table schema** with fields for user tracking, entity references, comments, and timestamps
- **Created TypeScript types** for FollowUp data structures and insert operations
- **Fixed column name spelling** from `entitiy_type` to `entity_type`

The calendar modal provides a comprehensive date browsing experience with smooth transitions between different time period views, all centered and accessible through the main header.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 154`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c20eb134139449ff9af32d1aa9923ffb/swoosh-space)

👀 [Preview Link](https://c20eb134139449ff9af32d1aa9923ffb-swoosh-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c20eb134139449ff9af32d1aa9923ffb</projectId>-->
<!--<branchName>swoosh-space</branchName>-->