### PR TITLE
Add FollowUp model and integrate with ActivityService

### DIFF
--- a/backend/src/models/FollowUp.ts
+++ b/backend/src/models/FollowUp.ts
@@ -9,9 +9,9 @@ export class FollowUpModel {
     const payload: InsertFollowUp = {
       ...data,
       id,
-      userId: data.userId,
-      entityId: data.entityId,
-      entityType: data.entityType,
+      userId: String(data.userId),
+      entityId: String(data.entityId),
+      entityType: String(data.entityType),
       comments: data.comments,
       followUpOn: data.followUpOn,
     };

--- a/backend/src/models/FollowUp.ts
+++ b/backend/src/models/FollowUp.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from "crypto";
+import { eq } from "drizzle-orm";
+import { db } from "../config/database.js";
+import { followUps, type FollowUp, type InsertFollowUp } from "../shared/schema.js";
+
+export class FollowUpModel {
+  static async create(data: InsertFollowUp): Promise<FollowUp> {
+    const id = data.id ?? randomUUID();
+    const payload: InsertFollowUp = {
+      ...data,
+      id,
+      userId: data.userId,
+      entityId: data.entityId,
+      entityType: data.entityType,
+      comments: data.comments,
+      followUpOn: data.followUpOn,
+    };
+
+    await db.insert(followUps).values(payload);
+
+    const [created] = await db.select().from(followUps).where(eq(followUps.id, id));
+    if (!created) {
+      throw new Error("Failed to persist follow-up record");
+    }
+
+    return created;
+  }
+}

--- a/backend/src/services/ActivityService.ts
+++ b/backend/src/services/ActivityService.ts
@@ -71,19 +71,19 @@ export class ActivityService {
     const rawType = String(activityWithUser.activityType ?? "").toLowerCase();
     const normalizedType = rawType.replace(/[\s_-]/g, "");
     if (normalizedType === "followup") {
-      const authorId = userId ?? (activityWithUser as any).userId;
+      const authorId = userId ?? activityWithUser.userId ?? undefined;
       if (!authorId) {
         await ActivityModel.delete(activity.id);
         throw new Error("User id is required to create follow-up records");
       }
 
-      const followUpOn = (activityWithUser as any).followUpAt ?? null;
+      const followUpOn = activityWithUser.followUpAt ?? null;
       if (!(followUpOn instanceof Date) || Number.isNaN(followUpOn.getTime())) {
         await ActivityModel.delete(activity.id);
         throw new Error("Follow-up date and time are required for follow-up activities");
       }
 
-      const descriptionSource = (activityWithUser as any).description ?? activityWithUser.title;
+      const descriptionSource = activityWithUser.description ?? activityWithUser.title;
       const comments = typeof descriptionSource === "string"
         ? descriptionSource.trim()
         : descriptionSource != null

--- a/backend/src/services/ActivityService.ts
+++ b/backend/src/services/ActivityService.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "crypto";
 import { ActivityModel } from "../models/Activity.js";
-import { UserModel } from "../models/User.js";
 import { AttachmentModel } from "../models/Attachment.js";
+import { FollowUpModel } from "../models/FollowUp.js";
+import { UserModel } from "../models/User.js";
 import { type Activity, type InsertActivity } from "../shared/schema.js";
 
 export class ActivityService {
@@ -53,18 +55,57 @@ export class ActivityService {
   }
 
   static async createActivity(activityData: InsertActivity): Promise<Activity> {
-    return await ActivityModel.create(activityData);
+    return await ActivityService.createActivityWithUser(activityData);
   }
 
   static async createActivityWithUser(activityData: InsertActivity, userId?: string): Promise<Activity> {
     // Do not persist userName and userProfileImage on activities; only store userId.
-    const activityWithUser: any = {
+    const activityWithUser: InsertActivity = {
       ...activityData,
       entityId: String(activityData.entityId), // Convert to string for consistency
       userId: userId || null,
     };
 
-    return await ActivityModel.create(activityWithUser as InsertActivity);
+    const activity = await ActivityModel.create(activityWithUser);
+
+    const rawType = String(activityWithUser.activityType ?? "").toLowerCase();
+    const normalizedType = rawType.replace(/[\s_-]/g, "");
+    if (normalizedType === "followup") {
+      const authorId = userId ?? (activityWithUser as any).userId;
+      if (!authorId) {
+        await ActivityModel.delete(activity.id);
+        throw new Error("User id is required to create follow-up records");
+      }
+
+      const followUpOn = (activityWithUser as any).followUpAt ?? null;
+      if (!(followUpOn instanceof Date) || Number.isNaN(followUpOn.getTime())) {
+        await ActivityModel.delete(activity.id);
+        throw new Error("Follow-up date and time are required for follow-up activities");
+      }
+
+      const descriptionSource = (activityWithUser as any).description ?? activityWithUser.title;
+      const comments = typeof descriptionSource === "string"
+        ? descriptionSource.trim()
+        : descriptionSource != null
+          ? String(descriptionSource)
+          : "";
+
+      try {
+        await FollowUpModel.create({
+          id: randomUUID(),
+          userId: String(authorId),
+          entityId: String(activity.entityId),
+          entityType: String(activity.entityType),
+          comments: comments || "Follow-up recorded",
+          followUpOn,
+        });
+      } catch (error) {
+        await ActivityModel.delete(activity.id);
+        throw error;
+      }
+    }
+
+    return activity;
   }
 
   static async logActivity(


### PR DESCRIPTION
## Changes Made

### New Files
- **backend/src/models/FollowUp.ts**: Created new FollowUpModel class with a `create` method that:
  - Accepts InsertFollowUp data and generates UUID if not provided
  - Converts userId, entityId, and entityType to strings
  - Inserts record into followUps table and retrieves the created record
  - Throws error if persistence fails

### Modified Files
- **backend/src/services/ActivityService.ts**: Enhanced ActivityService with follow-up functionality:
  - Added import for FollowUpModel and randomUUID
  - Modified `createActivity` method to call `createActivityWithUser`
  - Enhanced `createActivityWithUser` method to:
    - Handle follow-up activity types (normalized to remove spaces, underscores, hyphens)
    - Validate required userId and followUpAt date for follow-up activities
    - Create corresponding FollowUp records when activity type is "followup"
    - Extract comments from activity description or title
    - Implement rollback by deleting activity if follow-up creation fails

## Technical Details
- Follow-up detection uses case-insensitive string matching with normalization
- Error handling includes cleanup of created activities if follow-up creation fails
- String conversion ensures data consistency across entity references

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 155`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d5b6249ed76c4cca9cdc9d2239489ae2/zenith-oasis)

👀 [Preview Link](https://d5b6249ed76c4cca9cdc9d2239489ae2-zenith-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d5b6249ed76c4cca9cdc9d2239489ae2</projectId>-->
<!--<branchName>zenith-oasis</branchName>-->