### PR TITLE
Improve calendar modal header layout and remove year view

### DIFF
--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -109,8 +109,6 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
       }
       case 'month':
         return format(focusDate, 'MMMM yyyy');
-      case 'year':
-        return format(focusDate, 'yyyy');
       default:
         return '';
     }

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -36,13 +36,12 @@ interface CalendarModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
-type CalendarView = 'day' | 'week' | 'month' | 'year';
+type CalendarView = 'day' | 'week' | 'month';
 
 const viewOptions: { value: CalendarView; label: string }[] = [
   { value: 'day', label: 'Day' },
   { value: 'week', label: 'Week' },
   { value: 'month', label: 'Month' },
-  { value: 'year', label: 'Year' },
 ];
 
 const WEEK_OPTIONS = { weekStartsOn: 1 as const };

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -429,7 +429,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                   <Button
                     size="sm"
                     variant="outline"
-                    className="border-white/30 text-white hover:bg-white/15"
+                    className="border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20"
                     onClick={handlePrev}
                     aria-label="Previous period"
                   >
@@ -438,7 +438,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                   <Button
                     size="sm"
                     variant="outline"
-                    className="border-white/30 text-white hover:bg-white/15"
+                    className="border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20"
                     onClick={handleToday}
                   >
                     Today
@@ -446,7 +446,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                   <Button
                     size="sm"
                     variant="outline"
-                    className="border-white/30 text-white hover:bg-white/15"
+                    className="border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20"
                     onClick={handleNext}
                     aria-label="Next period"
                   >

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -411,7 +411,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                     variant={view === option.value ? 'default' : 'outline'}
                     className={
                       view === option.value
-                        ? 'border-[#102A5F] bg-[#102A5F] text-white hover:bg-[#102A5F]/90'
+                        ? 'border-[#0071B0] bg-[#0071B0] text-white hover:bg-[#00649D]'
                         : 'border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20'
                     }
                     onClick={() => setView(option.value)}

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { cn } from '@/lib/utils';

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -413,7 +413,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                       className={
                         view === option.value
                           ? 'border-white bg-white text-[#223E7D] hover:bg-white/90'
-                          : 'border-white/30 text-white/90 hover:bg-white/15'
+                          : 'border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20'
                       }
                       onClick={() => setView(option.value)}
                       aria-pressed={view === option.value}

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -412,7 +412,7 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                       variant={view === option.value ? 'default' : 'outline'}
                       className={
                         view === option.value
-                          ? 'border-white bg-white text-[#223E7D] hover:bg-white/90'
+                          ? 'border-[#102A5F] bg-[#102A5F] text-white hover:bg-[#102A5F]/90'
                           : 'border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20'
                       }
                       onClick={() => setView(option.value)}

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -225,8 +225,6 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
           return addDays(prev, 7);
         case 'month':
           return addMonths(prev, 1);
-        case 'year':
-          return addYears(prev, 1);
         default:
           return prev;
       }

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -75,14 +75,6 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
         return startOfMonth(selectedDate);
       });
     }
-    if (view === 'year') {
-      setFocusDate((prev) => {
-        if (prev.getFullYear() === selectedDate.getFullYear()) {
-          return prev;
-        }
-        return selectedDate;
-      });
-    }
   }, [view, selectedDate]);
 
   const monthForCalendar = React.useMemo(() => startOfMonth(focusDate), [focusDate]);

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -402,17 +402,33 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
       >
         <div className="flex h-full max-h-[90vh] flex-col">
           <div className="flex flex-col gap-3 border-b border-[#223E7D] bg-[#223E7D] text-white px-4 py-3 sm:px-6">
-            <div className="flex items-start justify-between gap-3">
-              <div>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0 flex-1 space-y-1">
                 <DialogTitle className="text-lg font-semibold text-white sm:text-xl">Calendar</DialogTitle>
                 <DialogDescription className="text-sm text-white/80">
                   Browse dates and plan upcoming activities.
                 </DialogDescription>
               </div>
-              <Button variant="ghost" size="icon" className="rounded-full w-8 h-8 bg-white text-[#223E7D] hover:bg-white/90" onClick={() => onOpenChange(false)}>
-                <span className="sr-only">Close</span>
-                <svg aria-hidden="true" viewBox="0 0 20 20" className="w-4 h-4"><path fill="currentColor" d="M11.414 10l3.536-3.536a1 1 0 10-1.414-1.414L10 8.586 6.464 5.05a1 1 0 10-1.414 1.414L8.586 10l-3.536 3.536a1 1 0 101.414 1.414L10 11.414l3.536 3.536a1 1 0 001.414-1.414L11.414 10z"/></svg>
-              </Button>
+              <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
+                <div className="flex flex-wrap justify-end gap-1">
+                  {viewOptions.map((option) => (
+                    <Button
+                      key={option.value}
+                      size="sm"
+                      variant={view === option.value ? 'default' : 'outline'}
+                      className={view === option.value ? 'bg-white text-[#223E7D] border-white hover:bg-white' : 'border-white/40 text-white hover:bg-white/10'}
+                      onClick={() => setView(option.value)}
+                      aria-pressed={view === option.value}
+                    >
+                      {option.label}
+                    </Button>
+                  ))}
+                </div>
+                <Button variant="ghost" size="icon" className="rounded-full w-8 h-8 bg-white text-[#223E7D] hover:bg-white/90" onClick={() => onOpenChange(false)}>
+                  <span className="sr-only">Close</span>
+                  <svg aria-hidden="true" viewBox="0 0 20 20" className="w-4 h-4"><path fill="currentColor" d="M11.414 10l3.536-3.536a1 1 0 10-1.414-1.414L10 8.586 6.464 5.05a1 1 0 10-1.414 1.414L8.586 10l-3.536 3.536a1 1 0 101.414 1.414L10 11.414l3.536 3.536a1 1 0 001.414-1.414L11.414 10z"/></svg>
+                </Button>
+              </div>
             </div>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div className="flex items-center gap-1">

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -431,47 +431,31 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
               </div>
             </div>
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex items-center gap-1">
-                {viewOptions.map((option) => (
-                  <Button
-                    key={option.value}
-                    size="sm"
-                    variant={view === option.value ? 'default' : 'outline'}
-                    className={view === option.value ? 'bg-white text-[#223E7D] border-white hover:bg-white' : 'border-white/40 text-white hover:bg-white/10'}
-                    onClick={() => setView(option.value)}
-                    aria-pressed={view === option.value}
-                  >
-                    {option.label}
-                  </Button>
-                ))}
+              <div className="min-w-0 text-sm font-medium text-white sm:text-base" aria-live="polite">
+                {viewLabel}
               </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <div className="text-sm font-medium text-white sm:text-base" aria-live="polite">
-                  {viewLabel}
-                </div>
-                <div className="flex items-center gap-1">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="border-white/40 text-white hover:bg-white/10"
-                    onClick={handlePrev}
-                    aria-label="Previous period"
-                  >
-                    <ChevronLeft className="h-4 w-4" />
-                  </Button>
-                  <Button size="sm" variant="outline" className="border-white/40 text-white hover:bg-white/10" onClick={handleToday}>
-                    Today
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="border-white/40 text-white hover:bg-white/10"
-                    onClick={handleNext}
-                    aria-label="Next period"
-                  >
-                    <ChevronRight className="h-4 w-4" />
-                  </Button>
-                </div>
+              <div className="flex flex-wrap items-center justify-end gap-1">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="border-white/40 text-white hover:bg-white/10"
+                  onClick={handlePrev}
+                  aria-label="Previous period"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button size="sm" variant="outline" className="border-white/40 text-white hover:bg-white/10" onClick={handleToday}>
+                  Today
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="border-white/40 text-white hover:bg-white/10"
+                  onClick={handleNext}
+                  aria-label="Next period"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
               </div>
             </div>
           </div>

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -404,7 +404,6 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
           <div className="flex flex-col gap-2 border-b border-[#223E7D] bg-[#223E7D] px-4 py-2 text-white sm:px-5">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
-                <DialogTitle className="text-base font-semibold text-white sm:text-lg">Calendar</DialogTitle>
                 <div className="flex flex-wrap items-center gap-1">
                   {viewOptions.map((option) => (
                     <Button

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -210,8 +210,6 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
           return subDays(prev, 7);
         case 'month':
           return subMonths(prev, 1);
-        case 'year':
-          return subYears(prev, 1);
         default:
           return prev;
       }

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -137,14 +137,6 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
           end: endOfDay(end),
         };
       }
-      case 'year': {
-        const start = startOfYear(focusDate);
-        const end = endOfYear(focusDate);
-        return {
-          start: startOfDay(start),
-          end: endOfDay(end),
-        };
-      }
       default:
         return {
           start: startOfDay(focusDate),

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -401,22 +401,21 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
         className="sm:max-w-5xl w-[95vw] max-h-[90vh] overflow-hidden border-0 bg-white p-0 shadow-xl"
       >
         <div className="flex h-full max-h-[90vh] flex-col">
-          <div className="flex flex-col gap-3 border-b border-[#223E7D] bg-[#223E7D] text-white px-4 py-3 sm:px-6">
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="min-w-0 flex-1 space-y-1">
-                <DialogTitle className="text-lg font-semibold text-white sm:text-xl">Calendar</DialogTitle>
-                <DialogDescription className="text-sm text-white/80">
-                  Browse dates and plan upcoming activities.
-                </DialogDescription>
-              </div>
-              <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
-                <div className="flex flex-wrap justify-end gap-1">
+          <div className="flex flex-col gap-2 border-b border-[#223E7D] bg-[#223E7D] px-4 py-2 text-white sm:px-5">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
+                <DialogTitle className="text-base font-semibold text-white sm:text-lg">Calendar</DialogTitle>
+                <div className="flex flex-wrap items-center gap-1">
                   {viewOptions.map((option) => (
                     <Button
                       key={option.value}
                       size="sm"
                       variant={view === option.value ? 'default' : 'outline'}
-                      className={view === option.value ? 'bg-white text-[#223E7D] border-white hover:bg-white' : 'border-white/40 text-white hover:bg-white/10'}
+                      className={
+                        view === option.value
+                          ? 'border-white bg-white text-[#223E7D] hover:bg-white/90'
+                          : 'border-white/30 text-white/90 hover:bg-white/15'
+                      }
                       onClick={() => setView(option.value)}
                       aria-pressed={view === option.value}
                     >
@@ -424,38 +423,45 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                     </Button>
                   ))}
                 </div>
-                <Button variant="ghost" size="icon" className="rounded-full w-8 h-8 bg-white text-[#223E7D] hover:bg-white/90" onClick={() => onOpenChange(false)}>
+              </div>
+              <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2">
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="border-white/30 text-white hover:bg-white/15"
+                    onClick={handlePrev}
+                    aria-label="Previous period"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="border-white/30 text-white hover:bg-white/15"
+                    onClick={handleToday}
+                  >
+                    Today
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="border-white/30 text-white hover:bg-white/15"
+                    onClick={handleNext}
+                    aria-label="Next period"
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+                <Button variant="ghost" size="icon" className="h-8 w-8 rounded-full bg-white text-[#223E7D] hover:bg-white/90" onClick={() => onOpenChange(false)}>
                   <span className="sr-only">Close</span>
-                  <svg aria-hidden="true" viewBox="0 0 20 20" className="w-4 h-4"><path fill="currentColor" d="M11.414 10l3.536-3.536a1 1 0 10-1.414-1.414L10 8.586 6.464 5.05a1 1 0 10-1.414 1.414L8.586 10l-3.536 3.536a1 1 0 101.414 1.414L10 11.414l3.536 3.536a1 1 0 001.414-1.414L11.414 10z"/></svg>
+                  <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4"><path fill="currentColor" d="M11.414 10l3.536-3.536a1 1 0 10-1.414-1.414L10 8.586 6.464 5.05a1 1 0 10-1.414 1.414L8.586 10l-3.536 3.536a1 1 0 101.414 1.414L10 11.414l3.536 3.536a1 1 0 001.414-1.414L11.414 10z"/></svg>
                 </Button>
               </div>
             </div>
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="min-w-0 text-sm font-medium text-white sm:text-base" aria-live="polite">
+            <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-white/70 sm:text-base">
+              <div className="min-w-0 truncate font-medium text-white" aria-live="polite">
                 {viewLabel}
-              </div>
-              <div className="flex flex-wrap items-center justify-end gap-1">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="border-white/40 text-white hover:bg-white/10"
-                  onClick={handlePrev}
-                  aria-label="Previous period"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </Button>
-                <Button size="sm" variant="outline" className="border-white/40 text-white hover:bg-white/10" onClick={handleToday}>
-                  Today
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="border-white/40 text-white hover:bg-white/10"
-                  onClick={handleNext}
-                  aria-label="Next period"
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
               </div>
             </div>
           </div>

--- a/frontend/src/components/calendar-modal.tsx
+++ b/frontend/src/components/calendar-modal.tsx
@@ -402,26 +402,27 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
       >
         <div className="flex h-full max-h-[90vh] flex-col">
           <div className="flex flex-col gap-2 border-b border-[#223E7D] bg-[#223E7D] px-4 py-2 text-white sm:px-5">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
-                <div className="flex flex-wrap items-center gap-1">
-                  {viewOptions.map((option) => (
-                    <Button
-                      key={option.value}
-                      size="sm"
-                      variant={view === option.value ? 'default' : 'outline'}
-                      className={
-                        view === option.value
-                          ? 'border-[#102A5F] bg-[#102A5F] text-white hover:bg-[#102A5F]/90'
-                          : 'border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20'
-                      }
-                      onClick={() => setView(option.value)}
-                      aria-pressed={view === option.value}
-                    >
-                      {option.label}
-                    </Button>
-                  ))}
-                </div>
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+              <div className="flex flex-wrap items-center gap-1">
+                {viewOptions.map((option) => (
+                  <Button
+                    key={option.value}
+                    size="sm"
+                    variant={view === option.value ? 'default' : 'outline'}
+                    className={
+                      view === option.value
+                        ? 'border-[#102A5F] bg-[#102A5F] text-white hover:bg-[#102A5F]/90'
+                        : 'border-[#223E7D]/40 text-[#223E7D] hover:bg-white/20'
+                    }
+                    onClick={() => setView(option.value)}
+                    aria-pressed={view === option.value}
+                  >
+                    {option.label}
+                  </Button>
+                ))}
+              </div>
+              <div className="flex flex-1 basis-full justify-center text-center text-sm font-medium text-white sm:basis-auto sm:text-base" aria-live="polite">
+                <span className="truncate">{viewLabel}</span>
               </div>
               <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2">
                 <div className="flex items-center gap-1">
@@ -456,11 +457,6 @@ export const CalendarModal: React.FC<CalendarModalProps> = ({ open, onOpenChange
                   <span className="sr-only">Close</span>
                   <svg aria-hidden="true" viewBox="0 0 20 20" className="h-4 w-4"><path fill="currentColor" d="M11.414 10l3.536-3.536a1 1 0 10-1.414-1.414L10 8.586 6.464 5.05a1 1 0 10-1.414 1.414L8.586 10l-3.536 3.536a1 1 0 101.414 1.414L10 11.414l3.536 3.536a1 1 0 001.414-1.414L11.414 10z"/></svg>
                 </Button>
-              </div>
-            </div>
-            <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-white/70 sm:text-base">
-              <div className="min-w-0 truncate font-medium text-white" aria-live="polite">
-                {viewLabel}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several UI/UX improvements to the calendar modal:
- Center the date range display in the header for better visual balance
- Update button styling to match the ADD activity button color scheme
- Fix visibility issues with navigation button text
- Remove the year view option as it's not needed

## Code changes

- **Removed year view**: Eliminated 'year' from CalendarView type and viewOptions array
- **Cleaned up year-related logic**: Removed year view handling in focus date updates, view labels, date ranges, and navigation functions
- **Restructured header layout**: Reorganized header into a more compact single-row layout with centered date display
- **Updated button styling**: Changed selected view button to use #0071B0 color (matching ADD activity button) instead of white
- **Improved navigation button styling**: Updated Today/Previous/Next buttons with better contrast using #223E7D text color
- **Enhanced responsive design**: Added better flex layout with proper spacing and text truncation
- **Removed unused imports**: Cleaned up DialogDescription import that's no longer needed

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 160`

🔗 [Edit in Builder.io](https://builder.io/app/projects/588c831907ff4007a2b7100029d657c0/zenith-field)

👀 [Preview Link](https://588c831907ff4007a2b7100029d657c0-zenith-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>588c831907ff4007a2b7100029d657c0</projectId>-->
<!--<branchName>zenith-field</branchName>-->