### PR TITLE
Add lead stats functionality and partner fields to schema

### DIFF
--- a/backend/src/shared/schema.ts
+++ b/backend/src/shared/schema.ts
@@ -230,6 +230,8 @@ export const leads = mysqlTable("leads", {
   eventRegId: varchar("event_reg_id", { length: 255 }),
   branchId: varchar("branch_id", { length: 255 }),
   regionId: varchar("region_id", { length: 50 }),
+  partner: varchar("partner", { length: 36 }),
+  subPartner: varchar("sub_partner", { length: 36 }),
   isConverted: int("is_converted").notNull().default(0),
   createdBy: varchar("created_by", { length: 255 }),
   updatedBy: varchar("updated_by", { length: 255 }),
@@ -267,6 +269,9 @@ export const students = mysqlTable("students", {
   regionId: varchar("region_id", { length: 50 }),
   counsellorId: varchar("counsellor_id", { length: 50 }),
   admissionOfficerId: varchar("admission_officer_id", { length: 50 }),
+  partner: varchar("partner", { length: 36 }),
+  subPartner: varchar("sub_partner", { length: 36 }),
+
 });
 
 
@@ -289,6 +294,9 @@ export const applications = mysqlTable("applications", {
   regionId: varchar("region_id", { length: 50 }),
   counsellorId: varchar("counsellor_id", { length: 50 }),
   admissionOfficerId: varchar("admission_officer_id", { length: 50 }),
+  partner: varchar("partner", { length: 36 }),
+  subPartner: varchar("sub_partner", { length: 36 }),
+
   universityId: varchar("university_id", { length: 50 }),
   courseId: varchar("course_id", { length: 50 }),
   intakeId: varchar("intake_id", { length: 50 }),
@@ -320,6 +328,8 @@ export const admissions = mysqlTable("admissions", {
   status: text("status"),
   caseStatus: text("case_status"),
   googleDriveLink: text("google_drive_link"),
+  partner: varchar("partner", { length: 36 }),
+  subPartner: varchar("sub_partner", { length: 36 }),
 
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
@@ -339,6 +349,8 @@ export const events = mysqlTable("events", {
   regionId: varchar("region_id", { length: 50 }),
   counsellorId: varchar("counsellor_id", { length: 50 }),
   admissionOfficerId: varchar("admission_officer_id", { length: 50 }),
+  partner: varchar("partner", { length: 36 }),
+  subPartner: varchar("sub_partner", { length: 36 }),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });


### PR DESCRIPTION
## Changes Made

### Lead Model Enhancements
- Added `LeadStats` interface with properties: `total`, `active`, `lost`, `converted`
- Added `LeadScope` interface for filtering by `counselorId`, `admissionOfficerId`, `branchId`, `regionId`
- Implemented `getStats()` method to calculate lead statistics with optional scope filtering
- Added helper methods:
  - `buildScopeConditions()` - builds SQL conditions from scope parameters
  - `combineConditions()` - combines multiple SQL conditions with AND logic
  - `countWithConditions()` - executes count queries with conditional filtering

### Database Schema Updates
- Added `partner` and `subPartner` varchar fields (length 36) to multiple tables:
  - `leads` table
  - `students` table  
  - `applications` table
  - `admissions` table
  - `events` table

### Import Changes
- Updated drizzle-orm imports to include `or` and `type SQL`
- Removed `sql` import (unused)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 163`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fc623305d48449158db4d4aa2db4ad34/swoosh-landing)

👀 [Preview Link](https://fc623305d48449158db4d4aa2db4ad34-swoosh-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fc623305d48449158db4d4aa2db4ad34</projectId>-->
<!--<branchName>swoosh-landing</branchName>-->